### PR TITLE
Disable tests for CentOS temporarily

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker-image: [centos, debian, fedora, ubuntu]
+        docker-image: [debian, fedora, ubuntu]
     steps:
     - uses: actions/checkout@v2
     - name: Setup docker container


### PR DESCRIPTION
- it still uses Python 3.6 per default, which we do not support

