### PR TITLE
Replace EOL CentOS with RedHat UBI9 docker image

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile_redhat
+++ b/.github/workflows/dockerfiles/Dockerfile_redhat
@@ -12,16 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:latest
-MAINTAINER jmcgeheeiv@users.noreply.github.com
+FROM registry.access.redhat.com/ubi9/ubi
+LABEL maintainer="John McGehee"
 
 ARG github_repo=pytest-dev/pyfakefs
 ARG github_branch=main
 
-RUN cd /etc/yum.repos.d/
-RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
-RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y
 RUN yum install -y python3-pip unzip wget
+RUN python3 --version
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docker-image: [debian, fedora, ubuntu]
+        docker-image: [debian, fedora, ubuntu, redhat]
     steps:
     - uses: actions/checkout@v2
     - name: Setup docker container

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: [3.9]
-        pytest-version: [3.0.0, 3.5.1, 4.0.2, 4.5.0, 5.0.1, 5.4.3, 6.0.2, 6.2.5, 7.0.1, 7.1.0]
+        pytest-version: [3.0.0, 3.5.1, 4.0.2, 4.5.0, 5.0.1, 5.4.3, 6.0.2, 6.2.5, 7.0.1, 7.1.3, 7.2.0]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Infrastructure
+* replaced end-of-life CentOS with RedHat UBI9 docker image
+* add tests for pytest 7.2.0
+
 ## [Version 5.0.0](https://pypi.python.org/pypi/pyfakefs/5.0.0) (2022-10-09)
 New version after the transfer to `pytest-dev`.
 


### PR DESCRIPTION
CentOS is no longer maintained (used to be a free mirror of RH), meanwhile RedHat has published its own public docker image with a subset of the commercial image, so we use that image for tests under RH.
