### PR TITLE
Add Python 3.12 to the test suite

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
         include:
           - python-version: "pypy-3.7"
             os: ubuntu-latest

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -6,14 +6,26 @@ on:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        experimental: [false]
         include:
-          - python-version: "pypy-3.7"
-            os: ubuntu-latest
+          - os: ubuntu-latest
+            python-version: "pypy-3.7"
+            experimental: false
+          - os: ubuntu-latest
+            python-version: "3.12-dev"
+            experimental: true
+          - os: macOS-latest
+            python-version: "3.12-dev"
+            experimental: true
+          - os: windows-latest
+            python-version: "3.12-dev"
+            experimental: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -68,7 +68,6 @@ jobs:
         python -m pyfakefs.tests.all_tests
       shell: bash
     - name: Run performance tests
-      if: ${{ python-version == "3.12-dev" }}
       run: |
         if [[ '${{ matrix.os  }}' != 'macOS-latest' ]]; then
           export TEST_PERFORMANCE=1

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -58,12 +58,12 @@ jobs:
         fi
       shell: bash
     - name: Install extra dependencies
-      if: ${{ python-version == "3.12-dev" }}
+      if: ${{ python-version != "3.12-dev" }}
       run: |
         pip install -r extra_requirements.txt
       shell: bash
     - name: Run unit tests with extra packages as non-root user
-      if: ${{ python-version == "3.12-dev" }}
+      if: ${{ python-version != "3.12-dev" }}
       run: |
         python -m pyfakefs.tests.all_tests
       shell: bash

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -6,26 +6,14 @@ on:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
-        experimental: [false]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
         include:
-          - os: ubuntu-latest
-            python-version: "pypy-3.7"
-            experimental: false
-          - os: ubuntu-latest
-            python-version: "3.12-dev"
-            experimental: true
-          - os: macOS-latest
-            python-version: "3.12-dev"
-            experimental: true
-          - os: windows-latest
-            python-version: "3.12-dev"
-            experimental: true
+          - python-version: "pypy-3.7"
+            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -70,17 +58,17 @@ jobs:
         fi
       shell: bash
     - name: Install extra dependencies
-      if: ${{ ! matrix.experimental }}
+      if: ${{ python-version == "3.12-dev" }}
       run: |
         pip install -r extra_requirements.txt
       shell: bash
     - name: Run unit tests with extra packages as non-root user
-      if: ${{ ! matrix.experimental }}
+      if: ${{ python-version == "3.12-dev" }}
       run: |
         python -m pyfakefs.tests.all_tests
       shell: bash
     - name: Run performance tests
-      if: ${{ ! matrix.experimental }}
+      if: ${{ python-version == "3.12-dev" }}
       run: |
         if [[ '${{ matrix.os  }}' != 'macOS-latest' ]]; then
           export TEST_PERFORMANCE=1

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -58,12 +58,12 @@ jobs:
         fi
       shell: bash
     - name: Install extra dependencies
-      if: ${{ python-version != "3.12-dev" }}
+      if: ${{ matrix.python-version != '3.12-dev' }}
       run: |
         pip install -r extra_requirements.txt
       shell: bash
     - name: Run unit tests with extra packages as non-root user
-      if: ${{ python-version != "3.12-dev" }}
+      if: ${{ matrix.python-version != '3.12-dev' }}
       run: |
         python -m pyfakefs.tests.all_tests
       shell: bash

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -70,14 +70,17 @@ jobs:
         fi
       shell: bash
     - name: Install extra dependencies
+      if: ${{ ! matrix.experimental }}
       run: |
         pip install -r extra_requirements.txt
       shell: bash
     - name: Run unit tests with extra packages as non-root user
+      if: ${{ ! matrix.experimental }}
       run: |
         python -m pyfakefs.tests.all_tests
       shell: bash
     - name: Run performance tests
+      if: ${{ ! matrix.experimental }}
       run: |
         if [[ '${{ matrix.os  }}' != 'macOS-latest' ]]; then
           export TEST_PERFORMANCE=1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,15 @@ The released versions correspond to PyPI releases.
 ### Features
 * added class level setup method `setUpClassPyfakefs` for unittest and class-scoped
   fixture `fs_class` for pytest (see [#752](../../issues/752))
+* added experimental support for Python 3.12: added fake APIs for Windows junction
+  support. These are not implemented and always return `False`.
 
 ### Infrastructure
 * replaced end-of-life CentOS with RedHat UBI9 docker image
 * added tests for pytest 7.2.0
 * added black to pre-commit checks, which caused some changes to the
   coding style (max line length is now 88, always use double quotes)
+* added Python 3.12 to the test suite.
 
 ## [Version 5.0.0](https://pypi.python.org/pypi/pyfakefs/5.0.0) (2022-10-09)
 New version after the transfer to `pytest-dev`.

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -578,8 +578,7 @@ class FakeFile:
 
     @property
     def is_junction(self) -> bool:
-        # TODO: implement junctions
-        return False
+        return self.filesystem.isjunction(self.path)
 
     def __getattr__(self, item: str) -> Any:
         """Forward some properties to stat_result."""
@@ -3446,19 +3445,7 @@ class FakeFilesystem:
         return self._is_of_type(path, S_IFLNK, follow_symlinks=False)
 
     def isjunction(self, path: AnyPath) -> bool:
-        """Determine if path identifies a junction.
-
-        Args:
-            path: Path to filesystem object.
-
-        Returns:
-            `False` on posix systems.
-            `True` if path is a junction on Windows.
-
-        Raises:
-            TypeError: if path is None.
-        """
-        # TODO: implement junction on Windows
+        """Junction are never faked."""
         return False
 
     def confirmdir(
@@ -3725,17 +3712,7 @@ class FakePathModule:
         return self.filesystem.islink(path)
 
     def isjunction(self, path: AnyStr) -> bool:
-        """Determine whether path is a junction.
-
-        Args:
-            path: Path to filesystem object.
-
-        Returns:
-            `True` if path is a junction.
-
-        Raises:
-            TypeError: if path is None.
-        """
+        """Junction are never faked."""
         return self.filesystem.isjunction(path)
 
     def getmtime(self, path: AnyStr) -> float:

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -576,6 +576,11 @@ class FakeFile:
             dir_path = sep.join(names)
         return self.filesystem.absnormpath(dir_path)
 
+    @property
+    def is_junction(self) -> bool:
+        # TODO: implement junctions
+        return False
+
     def __getattr__(self, item: str) -> Any:
         """Forward some properties to stat_result."""
         if item in self.stat_types:
@@ -3440,6 +3445,22 @@ class FakeFilesystem:
         """
         return self._is_of_type(path, S_IFLNK, follow_symlinks=False)
 
+    def isjunction(self, path: AnyPath) -> bool:
+        """Determine if path identifies a junction.
+
+        Args:
+            path: Path to filesystem object.
+
+        Returns:
+            `False` on posix systems.
+            `True` if path is a junction on Windows.
+
+        Raises:
+            TypeError: if path is None.
+        """
+        # TODO: implement junction on Windows
+        return False
+
     def confirmdir(
         self, target_directory: AnyStr, check_owner: bool = False
     ) -> FakeDirectory:
@@ -3602,6 +3623,7 @@ class FakePathModule:
             "isdir",
             "isfile",
             "islink",
+            "isjunction",
             "ismount",
             "join",
             "lexists",
@@ -3701,6 +3723,20 @@ class FakePathModule:
             TypeError: if path is None.
         """
         return self.filesystem.islink(path)
+
+    def isjunction(self, path: AnyStr) -> bool:
+        """Determine whether path is a junction.
+
+        Args:
+            path: Path to filesystem object.
+
+        Returns:
+            `True` if path is a junction.
+
+        Raises:
+            TypeError: if path is None.
+        """
+        return self.filesystem.isjunction(path)
 
     def getmtime(self, path: AnyStr) -> float:
         """Returns the modification time of the fake file.

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -576,9 +576,11 @@ class FakeFile:
             dir_path = sep.join(names)
         return self.filesystem.absnormpath(dir_path)
 
-    @property
-    def is_junction(self) -> bool:
-        return self.filesystem.isjunction(self.path)
+    if sys.version_info >= (3, 12):
+
+        @property
+        def is_junction(self) -> bool:
+            return self.filesystem.isjunction(self.path)
 
     def __getattr__(self, item: str) -> Any:
         """Forward some properties to stat_result."""
@@ -3444,9 +3446,11 @@ class FakeFilesystem:
         """
         return self._is_of_type(path, S_IFLNK, follow_symlinks=False)
 
-    def isjunction(self, path: AnyPath) -> bool:
-        """Junction are never faked."""
-        return False
+    if sys.version_info >= (3, 12):
+
+        def isjunction(self, path: AnyPath) -> bool:
+            """Junction are never faked."""
+            return False
 
     def confirmdir(
         self, target_directory: AnyStr, check_owner: bool = False
@@ -3597,7 +3601,7 @@ class FakePathModule:
         """Return the list of patched function names. Used for patching
         functions imported from the module.
         """
-        return [
+        dir_list = [
             "abspath",
             "dirname",
             "exists",
@@ -3610,7 +3614,6 @@ class FakePathModule:
             "isdir",
             "isfile",
             "islink",
-            "isjunction",
             "ismount",
             "join",
             "lexists",
@@ -3622,6 +3625,9 @@ class FakePathModule:
             "splitdrive",
             "samefile",
         ]
+        if sys.version_info >= (3, 12):
+            dir_list.append("isjunction")
+        return dir_list
 
     def __init__(self, filesystem: FakeFilesystem, os_module: "FakeOsModule"):
         """Init.
@@ -3711,9 +3717,11 @@ class FakePathModule:
         """
         return self.filesystem.islink(path)
 
-    def isjunction(self, path: AnyStr) -> bool:
-        """Junction are never faked."""
-        return self.filesystem.isjunction(path)
+    if sys.version_info >= (3, 12):
+
+        def isjunction(self, path: AnyStr) -> bool:
+            """Junction are never faked."""
+            return self.filesystem.isjunction(path)
 
     def getmtime(self, path: AnyStr) -> float:
         """Returns the modification time of the fake file.

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -3449,7 +3449,7 @@ class FakeFilesystem:
     if sys.version_info >= (3, 12):
 
         def isjunction(self, path: AnyPath) -> bool:
-            """Junction are never faked."""
+            """Returns False. Junctions are never faked."""
             return False
 
     def confirmdir(
@@ -3720,7 +3720,7 @@ class FakePathModule:
     if sys.version_info >= (3, 12):
 
         def isjunction(self, path: AnyStr) -> bool:
-            """Junction are never faked."""
+            """Returns False. Junctions are never faked."""
             return self.filesystem.isjunction(path)
 
     def getmtime(self, path: AnyStr) -> float:

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -32,8 +32,10 @@ import errno
 import fnmatch
 import functools
 import inspect
+import ntpath
 import os
 import pathlib
+import posixpath
 import re
 import sys
 from pathlib import PurePath
@@ -383,6 +385,7 @@ class _FakeWindowsFlavour(_FakeFlavour):
         | {"COM%d" % i for i in range(1, 10)}
         | {"LPT%d" % i for i in range(1, 10)}
     )
+    pathmod = ntpath
 
     def is_reserved(self, parts):
         """Return True if the path is considered reserved under Windows."""
@@ -458,6 +461,8 @@ class _FakePosixFlavour(_FakeFlavour):
     """Flavour used by PurePosixPath with some Unix specific implementations
     independent of FakeFilesystem properties.
     """
+
+    pathmod = posixpath
 
     def is_reserved(self, parts):
         return False

--- a/pyfakefs/fake_scandir.py
+++ b/pyfakefs/fake_scandir.py
@@ -114,6 +114,16 @@ class DirEntry(BaseClass):
         def __fspath__(self):
             return self.path
 
+    if sys.version_info >= (3, 12):
+
+        def is_junction(self) -> bool:
+            """Return True if this entry is a junction.
+            Junctions are not a part of posix semantic."""
+            if not self._filesystem.is_windows_fs:
+                return False
+            file_object = self._filesystem.resolve(self._abspath)
+            return file_object.is_junction
+
 
 class ScanDirIter:
     """Iterator for DirEntry objects returned from `scandir()`

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -632,6 +632,7 @@ class FakePathlibPathFileOperationTest(RealPathlibTestCase):
         self.assertTrue(path.is_symlink())
 
     @unittest.skipIf(sys.version_info < (3, 8), "link_to new in Python 3.8")
+    @unittest.skipIf(sys.version_info >= (3, 12), "link_to removed in Python 3.12")
     def test_link_to(self):
         self.skip_if_symlink_not_supported()
         file_name = self.make_path("foo", "bar.txt")

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -513,6 +513,15 @@ class FakePathlibPathFileOperationTest(RealPathlibTestCase):
         file_path = self.path(self.make_path("text_file"))
         self.assertEqual(file_path.read_text(), "foo")
 
+    @unittest.skipIf(
+        sys.version_info < (3, 12),
+        "is_junction method new in Python 3.12",
+    )
+    def test_is_junction(self):
+        self.create_file(self.make_path("text_file"), contents="foo")
+        file_path = self.path(self.make_path("text_file"))
+        self.assertFalse(file_path.is_junction())
+
     def test_read_text_with_encoding(self):
         self.create_file(
             self.make_path("text_file"), contents="ерунда", encoding="cyrillic"


### PR DESCRIPTION
#### Describe the changes
I know this is quite early 😄 but I was trying to test one of my packages to see if it worked and noticed that pyfakefs was returning some errors. I fixed a few issues to make it work on my machine (macOS) but it looks like it now fails due to pandas not installing yet. Also Windows fails but I don't have such a machine, so I might not be the best person to fix these...

Let me know how I should proceed with this. I understand if you want to close or leave this pull request open until all the jobs pass. I'm also happy to split the fixes and leave the CI updates out for now.

However, I do think that having basic support in this package might help others packages to add Python 3.12 compatibility.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
