### PR TITLE
Fix dockertests on branches containing slashes

### DIFF
--- a/.github/workflows/dockerfiles/Dockerfile_debian
+++ b/.github/workflows/dockerfiles/Dockerfile_debian
@@ -32,8 +32,8 @@ RUN apt-get clean
 RUN useradd -u 1000 pyfakefs
 
 RUN mkdir -p work \
-    && wget https://github.com/$github_repo/archive/$github_branch.zip \
-    && unzip $github_branch.zip -d work
+    && wget https://github.com/$github_repo/archive/$github_branch.zip -O archive.zip \
+    && unzip archive.zip -d work
 RUN WORK_DIR=`ls -d work/*`; mv $WORK_DIR work/pyfakefs
 RUN chown -R pyfakefs:pyfakefs work/pyfakefs
 WORKDIR work/pyfakefs

--- a/.github/workflows/dockerfiles/Dockerfile_fedora
+++ b/.github/workflows/dockerfiles/Dockerfile_fedora
@@ -26,8 +26,8 @@ RUN dnf install -y python3-pip unzip wget
 RUN useradd -u 1000 pyfakefs
 
 RUN mkdir -p work \
-    && wget https://github.com/$github_repo/archive/$github_branch.zip \
-    && unzip $github_branch.zip -d work
+    && wget https://github.com/$github_repo/archive/$github_branch.zip -O archive.zip \
+    && unzip archive.zip -d work
 RUN WORK_DIR=`ls -d work/*`; mv $WORK_DIR work/pyfakefs
 RUN chown -R pyfakefs:pyfakefs work/pyfakefs
 WORKDIR work/pyfakefs

--- a/.github/workflows/dockerfiles/Dockerfile_redhat
+++ b/.github/workflows/dockerfiles/Dockerfile_redhat
@@ -29,8 +29,8 @@ ENV LC_COLLATE C.UTF-8
 RUN useradd -u 1000 pyfakefs
 
 RUN mkdir -p work \
-    && wget https://github.com/$github_repo/archive/$github_branch.zip \
-    && unzip $github_branch.zip -d work
+    && wget https://github.com/$github_repo/archive/$github_branch.zip -O archive.zip \
+    && unzip archive.zip -d work
 RUN WORK_DIR=`ls -d work/*`; mv $WORK_DIR work/pyfakefs
 RUN chown -R pyfakefs:pyfakefs work/pyfakefs
 WORKDIR work/pyfakefs

--- a/.github/workflows/dockerfiles/Dockerfile_ubuntu
+++ b/.github/workflows/dockerfiles/Dockerfile_ubuntu
@@ -32,8 +32,8 @@ RUN apt-get clean
 RUN useradd -u 1000 pyfakefs
 
 RUN mkdir -p work \
-    && wget https://github.com/$github_repo/archive/$github_branch.zip \
-    && unzip $github_branch.zip -d work
+    && wget https://github.com/$github_repo/archive/$github_branch.zip -O archive.zip \
+    && unzip archive.zip -d work
 RUN WORK_DIR=`ls -d work/*`; mv $WORK_DIR work/pyfakefs
 RUN chown -R pyfakefs:pyfakefs work/pyfakefs
 WORKDIR work/pyfakefs

--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -14,6 +14,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup docker container
       run: |
-        docker build -t pyfakefs -f $GITHUB_WORKSPACE/.github/workflows/dockerfiles/Dockerfile_${{ matrix.docker-image }} . --build-arg github_repo=$GITHUB_REPOSITORY --build-arg github_branch=$(basename $GITHUB_REF)
+        docker build -t pyfakefs -f $GITHUB_WORKSPACE/.github/workflows/dockerfiles/Dockerfile_${{ matrix.docker-image }} . --build-arg github_repo=$GITHUB_REPOSITORY --build-arg github_branch=$GITHUB_REF_NAME
     - name: Run tests
       run: docker run -t pyfakefs

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ The released versions correspond to PyPI releases.
   coding style (max line length is now 88, always use double quotes)
 * added Python 3.12 to the test suite.
 * migrated to [setuptools declarative syntax](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html).
+* fixed docker tests when running on branches containing forward slashes
 
 ## [Version 5.0.0](https://pypi.python.org/pypi/pyfakefs/5.0.0) (2022-10-09)
 New version after the transfer to `pytest-dev`.


### PR DESCRIPTION
#### Describe the changes
I noticed that the dockertests [were failing](https://github.com/browniebroke/pyfakefs/actions/runs/3766893340/jobs/6403878811#step:3:977) on my branches. 

I thought it was because they are on a fork, but it's actually because my branches contained slashes `/` which means the [`$(basename $GITHUB_REF)`](https://github.com/pytest-dev/pyfakefs/blob/c617fceb91bf5e4331752fcabb9c1620859b3222/.github/workflows/dockertests.yml#L17) didn't resolve correctly to the branch name. GitHub provides another env variable `GITHUB_REF_NAME` which contains the correct value, so we can just use that instead. 

Fixing this [broke the `unzip` commands](https://github.com/browniebroke/pyfakefs/actions/runs/3766946009/jobs/6403987731#step:3:989) in the Dockerfiles, which we can avoid by setting the filename with `-O` when downloading with `wget`.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
