### PR TITLE
Add "force_unix_mode" flag to FakeFilesystem.chmod

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Features
+* added possibility to set a path inaccessible under Windows by using `chown()` with
+  the `force_unix_mode` flag (see [#720](../../issues/720))
+
 ## [Version 5.1.0](https://pypi.python.org/pypi/pyfakefs/5.1.0) (2023-01-12)
 New version before Debian freeze
 


### PR DESCRIPTION
- makes it possible to simulate inaccessible paths under Windows
- see #720

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
