### PR TITLE
remove engine overwrite in pandas TextFileReader patch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ The released versions correspond to PyPI releases.
   `fake_io.FakeIoModule` and `fake_open.FakeFileOpen`. Additionally, all fake file
   classes have been moved to `fake_file`. While most of the changes shall be upwards
   compatible, we cannot exclude that we missed some problems.
+* Patching of parsers for pandas >= 1.2 is removed since pandas now uses Python fs functions
+  internally even when the engine selected is "c".
 
 ### Features
 * added possibility to set a path inaccessible under Windows by using `chown()` with

--- a/pyfakefs/patched_packages.py
+++ b/pyfakefs/patched_packages.py
@@ -123,6 +123,7 @@ if patch_pandas:
 
         class TextFileReader(parsers.TextFileReader):
             def __init__(self, *args, **kwargs):
+                kwargs["engine"] = "python"
                 super().__init__(*args, **kwargs)
 
         def __getattr__(self, name):

--- a/pyfakefs/patched_packages.py
+++ b/pyfakefs/patched_packages.py
@@ -32,6 +32,13 @@ try:
 except ImportError:
     locks = None
 
+# From pandas v 1.2 onwards the python fs functions are used even when the engine
+# selected is "c". This means that we don't explicitly have to change the engine.
+patch_pandas = parsers is not None and [int(v) for v in pd.__version__.split(".")] < [
+    1,
+    2,
+    0,
+]
 
 def get_modules_to_patch():
     modules_to_patch = {}
@@ -44,14 +51,14 @@ def get_modules_to_patch():
 
 def get_classes_to_patch():
     classes_to_patch = {}
-    if parsers is not None:
+    if patch_pandas:
         classes_to_patch["TextFileReader"] = "pandas.io.parsers"
     return classes_to_patch
 
 
 def get_fake_module_classes():
     fake_module_classes = {}
-    if parsers is not None:
+    if patch_pandas:
         fake_module_classes["TextFileReader"] = FakeTextFileReader
     return fake_module_classes
 
@@ -95,13 +102,6 @@ if xlrd is not None:
             return getattr(self._xlrd_module, name)
 
 
-# From pandas v 1.2 onwards the python fs functions are used even when the engine
-# selected is "c". This means that we don't explicitly have to change the engine.
-patch_pandas = parsers is not None and [int(v) for v in pd.__version__.split(".")] < [
-    1,
-    2,
-    0,
-]
 if patch_pandas:
     # we currently need to add fake modules for both the parser module and
     # the contained text reader - maybe this can be simplified

--- a/pyfakefs/patched_packages.py
+++ b/pyfakefs/patched_packages.py
@@ -97,9 +97,11 @@ if xlrd is not None:
 
 # From pandas v 1.2 onwards the python fs functions are used even when the engine selected is "c".
 # This means that we don't explicitly have to change the engine.
-patch_pandas = (
-        parsers is not None and [int(v) for v in pd.__version__.split(".")] < [1, 2, 0]
-)
+patch_pandas = parsers is not None and [int(v) for v in pd.__version__.split(".")] < [
+    1,
+    2,
+    0,
+]
 if patch_pandas:
     # we currently need to add fake modules for both the parser module and
     # the contained text reader - maybe this can be simplified

--- a/pyfakefs/patched_packages.py
+++ b/pyfakefs/patched_packages.py
@@ -17,6 +17,7 @@ with pyfakefs.
 import sys
 
 try:
+    import pandas as pd
     import pandas.io.parsers as parsers
 except ImportError:
     parsers = None
@@ -94,7 +95,12 @@ if xlrd is not None:
             return getattr(self._xlrd_module, name)
 
 
-if parsers is not None:
+# From pandas v 1.2 onwards the python fs functions are used even when the engine selected is "c".
+# This means that we don't explicitly have to change the engine.
+patch_pandas = (
+        parsers is not None and [int(v) for v in pd.__version__.split(".")] < [1, 2, 0]
+)
+if patch_pandas:
     # we currently need to add fake modules for both the parser module and
     # the contained text reader - maybe this can be simplified
 

--- a/pyfakefs/patched_packages.py
+++ b/pyfakefs/patched_packages.py
@@ -40,6 +40,7 @@ patch_pandas = parsers is not None and [int(v) for v in pd.__version__.split("."
     0,
 ]
 
+
 def get_modules_to_patch():
     modules_to_patch = {}
     if xlrd is not None:

--- a/pyfakefs/patched_packages.py
+++ b/pyfakefs/patched_packages.py
@@ -117,7 +117,6 @@ if parsers is not None:
 
         class TextFileReader(parsers.TextFileReader):
             def __init__(self, *args, **kwargs):
-                kwargs["engine"] = "python"
                 super().__init__(*args, **kwargs)
 
         def __getattr__(self, name):

--- a/pyfakefs/patched_packages.py
+++ b/pyfakefs/patched_packages.py
@@ -95,8 +95,8 @@ if xlrd is not None:
             return getattr(self._xlrd_module, name)
 
 
-# From pandas v 1.2 onwards the python fs functions are used even when the engine selected is "c".
-# This means that we don't explicitly have to change the engine.
+# From pandas v 1.2 onwards the python fs functions are used even when the engine
+# selected is "c". This means that we don't explicitly have to change the engine.
 patch_pandas = parsers is not None and [int(v) for v in pd.__version__.split(".")] < [
     1,
     2,


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are still in progress.
-->

#### Describe the changes
TextFileReader currently overwrites the engine as python when patching for pandas. I am not sure why is it needed since the default engine is "c" and "python" engine doesn't expects certain params like "float_precision" which results in it failing with the version of pandas that we have (1.1.5).

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
