### PR TITLE
Create /tmp symlink to temp dir under macOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ The released versions correspond to PyPI releases.
   `fake_io.FakeIoModule` and `fake_open.FakeFileOpen`. Additionally, all fake file
   classes have been moved to `fake_file`. While most of the changes shall be upwards
   compatible, we cannot exclude that we missed some problems.
+* Under macOS, at test start a symlink `/tmp` to the actual temporary directory is
+  now created in the fake filesystem.
 
 ### Features
 * added possibility to set a path inaccessible under Windows by using `chown()` with

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -156,7 +156,7 @@ a temporary directory is required to ensure that ``tempfile`` works correctly,
 e.g., that ``tempfile.gettempdir()`` will return a valid value. This
 means that any newly created fake file system will always have either a
 directory named ``/tmp`` when running on Linux or Unix systems,
-``/var/folders/<hash>/T`` when running on MacOs, or
+``/var/folders/<hash>/T`` when running on macOS, or
 ``C:\Users\<user>\AppData\Local\Temp`` on Windows:
 
 .. code:: python
@@ -168,6 +168,8 @@ directory named ``/tmp`` when running on Linux or Unix systems,
       # the temp directory is always present at test start
       assert len(os.listdir("/")) == 1
 
+Under macOS, a symlink to the actual temp directory is created additionally as `/tmp`
+in the fake filesystem.
 
 User rights
 -----------

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -634,6 +634,21 @@ class TestPyfakefsTestCase(unittest.TestCase):
         self.assertIsInstance(self.test_case, fake_filesystem_unittest.TestCaseMixin)
 
 
+class TestTempDirCreation(fake_filesystem_unittest.TestCase):
+    """Test that the temp directory exists at test start."""
+
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def testTempDirExists(self):
+        self.assertTrue(os.path.exists(tempfile.gettempdir()))
+
+    @unittest.skipIf(sys.platform == "win32", "POSIX only test")
+    def testTmpExists(self):
+        # directory under Linux, link under macOS
+        self.assertTrue(os.path.exists("/tmp"))
+
+
 class TestTempFileReload(unittest.TestCase):
     """Regression test for #356 to make sure that reloading the tempfile
     does not affect other tests."""


### PR DESCRIPTION
- always exists to conform to the POSIX standard in the real fs
- do not add the used space for the link for test convenience
- see #790

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
