### PR TITLE
Set the os.supports_xxx properties for the fake filesystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 # pyfakefs Release Notes
 The released versions correspond to PyPI releases.
 
+## Unreleased
+
+### Fixes
+* Properties defining the capabilities of some `os` functions like
+  `os.supports_follow_symlinks` are now properly faked to contain the fake functions
+  if the real functions are faked (see [#799](../../issues/799))
+
 ## [Version 5.2.0](https://pypi.python.org/pypi/pyfakefs/5.2.0) (2023-03-31)
 Supports current Python 3.12 version (alpha 6). We plan to make patch releases in
 case of breaking changes in alpha or beta versions.

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -132,7 +132,7 @@ class _FakeAccessor(accessor):  # type: ignore [valid-type, misc]
 
             if (
                 not kwargs["follow_symlinks"]
-                and os.os_module.chmod not in os.supports_follow_symlinks
+                and os.os_module.chmod not in os.os_module.supports_follow_symlinks
             ):
                 raise NotImplementedError(
                     "`follow_symlinks` for chmod() is not available " "on this system"

--- a/pyfakefs/tests/fake_filesystem_shutil_test.py
+++ b/pyfakefs/tests/fake_filesystem_shutil_test.py
@@ -231,6 +231,17 @@ class FakeShutilModuleTest(RealFsTestCase):
         self.assertAlmostEqual(src_stat.st_atime, dst_stat.st_atime, places=2)
         self.assertAlmostEqual(src_stat.st_mtime, dst_stat.st_mtime, places=2)
 
+    def test_copystat_symlinks(self):
+        """Regression test for #799"""
+        self.skip_if_symlink_not_supported()
+        f = self.make_path("xyzzy")
+        self.create_file(f)
+        sym1 = self.make_path("sym1")
+        sym2 = self.make_path("sym2")
+        self.create_symlink(sym1, f)
+        self.create_symlink(sym2, f)
+        shutil.copystat(sym1, sym2, follow_symlinks=False)
+
     def test_copy2(self):
         src_file = self.make_path("xyzzy")
         self.create_file(src_file)

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -402,7 +402,7 @@ class FakePathlibFileObjectPropertyTest(RealPathlibTestCase):
         self.skip_if_symlink_not_supported()
         file_stat = self.os.stat(self.file_path)
         link_stat = self.os.lstat(self.file_link_path)
-        if self.real_os.chmod not in os.supports_follow_symlinks or IS_PYPY:
+        if self.os.chmod not in self.os.supports_follow_symlinks or IS_PYPY:
             with self.assertRaises(NotImplementedError):
                 self.path(self.file_link_path).chmod(0o444, follow_symlinks=False)
         else:


### PR DESCRIPTION
- return the faked functions instead of the real ones
- fixes #799

The problem was that until now, the `os.supports_..` properties have been taken from the real `os` in `pyfakefs` itself. This does not work if called by someone in the faked os who checks for a contained function, as it would have found the original instead of the faked function.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
