### PR TITLE
Re-create the temp directory on resetting the filesystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # pyfakefs Release Notes
 The released versions correspond to PyPI releases.
 
+## Unreleased
+
+### Fixes
+* Re-create temp directory if it had been created before on resetting file system
+  (see [#814](../../issues/814)).
+
 ## [Version 5.2.2](https://pypi.python.org/pypi/pyfakefs/5.2.2) (2023-04-13)
 Fixes a regression in 5.2.0
 

--- a/pyfakefs/pytest_tests/pytest_plugin_test.py
+++ b/pyfakefs/pytest_tests/pytest_plugin_test.py
@@ -2,6 +2,7 @@
 import os
 import tempfile
 
+from pyfakefs.fake_filesystem import OSType
 from pyfakefs.fake_filesystem_unittest import Pause
 import pyfakefs.pytest_tests.io
 
@@ -60,3 +61,18 @@ def test_use_own_io_module(fs):
 
     stream = pyfakefs.pytest_tests.io.InputStream(filepath)
     assert stream.read() == "bar"
+
+
+def test_switch_to_windows(fs):
+    fs.os = OSType.WINDOWS
+    assert os.path.exists(tempfile.gettempdir())
+
+
+def test_switch_to_linux(fs):
+    fs.os = OSType.LINUX
+    assert os.path.exists(tempfile.gettempdir())
+
+
+def test_switch_to_macos(fs):
+    fs.os = OSType.MACOS
+    assert os.path.exists(tempfile.gettempdir())

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -657,11 +657,11 @@ class TestTempDirCreation(fake_filesystem_unittest.TestCase):
     def setUp(self):
         self.setUpPyfakefs()
 
-    def testTempDirExists(self):
+    def test_tempdir_exists(self):
         self.assertTrue(os.path.exists(tempfile.gettempdir()))
 
     @unittest.skipIf(sys.platform == "win32", "POSIX only test")
-    def testTmpExists(self):
+    def test_tmp_exists(self):
         # directory or link under Linux, link under macOS
         self.assertTrue(os.path.exists("/tmp"))
 


### PR DESCRIPTION
- the temp dir is now created during filesystem initialization instead of at patcher setup
- fixes #814

This slightly changes the behavior if you are creating a fake filesystem without using any of the recommended methods (e.g. the temp directory is now also created in this case), but I think that this is ok.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
