### PR TITLE
Add macOS pytest tests in CI

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -80,9 +80,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         python-version: [3.9]
-        pytest-version: [3.0.0, 3.5.1, 4.0.2, 4.5.0, 5.0.1, 5.4.3, 6.0.2, 6.2.5, 7.0.1, 7.1.3, 7.2.0]
+        pytest-version: [3.0.0, 3.5.1, 4.0.2, 4.5.0, 5.0.1, 5.4.3, 6.0.2, 6.2.5, 7.0.1, 7.1.3, 7.2.0, 7.3.1]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Make sure pytest tests also work under macOS, see #814.