### PR TITLE
tox.ini: passenv should be comma-separated, not space-separated

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py37,py38,py39,py310,py311,pypy3
 deps =
     -rrequirements.txt
     -rextra_requirements.txt
-passenv = HOME USERPROFILE
+passenv = HOME,USERPROFILE
 commands=
     python -m pyfakefs.tests.all_tests
     python -m pyfakefs.tests.all_tests_without_extra_packages


### PR DESCRIPTION
#### Describe the changes

```
[jelle@⬢ python311][~/projects/pyfakefs]%HOME=1 USERPROFILE=2 tox -e py311
py311: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'HOME USERPROFILE'
  py311: FAIL code 1 (0.00 seconds)
  evaluation failed :( (0.03 seconds)
```

See: https://github.com/tox-dev/tox/issues/2658

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
