### PR TITLE
Adapt fake shutil to changes in Python 3.12 beta2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@ The released versions correspond to PyPI releases.
 * Exclude pytest `pathlib` modules from patching to avoid mixup of patched/unpatched
   code (see [#814](../../issues/814)).
 * Adapt to changes in Python 3.12 beta1 (only working partially,
-  see [#830](../../issues/830) and [#831](../../issues/831))
+  see [#830](../../issues/830) and [#831](../../issues/831)).
+* Adapt to changes in `shutil` in Python 3.12 beta2 (see [#814](../../issues/814)).
 
 ### Infrastructure
 * Added pytype check for non-test modules in CI (see [#599](../../issues/599)).

--- a/pyfakefs/fake_filesystem_shutil.py
+++ b/pyfakefs/fake_filesystem_shutil.py
@@ -26,8 +26,9 @@ work fine with the fake file system if `os`/`os.path` are patched.
   `fake_filesystem_unittest.TestCase`, pytest fs fixture,
   or directly `Patcher`.
 """
-
+import os
 import shutil
+import sys
 
 
 class FakeShutilModule:
@@ -59,6 +60,49 @@ class FakeShutilModule:
           path: defines the filesystem device which is queried
         """
         return self.filesystem.get_disk_usage(path)
+
+    if sys.version_info >= (3, 12) and sys.platform == "win32":
+
+        def copy2(self, src, dst, *, follow_symlinks=True):
+            """Since Python 3.12, there is an optimization fow Windows,
+            using the Windows API. We just remove this and fall back to the previous
+            implementation.
+            """
+            if self.filesystem.isdir(dst):
+                dst = self.filesystem.joinpaths(dst, os.path.basename(src))
+
+            self.copyfile(src, dst, follow_symlinks=follow_symlinks)
+            self.copystat(src, dst, follow_symlinks=follow_symlinks)
+            return dst
+
+        def copytree(
+            self,
+            src,
+            dst,
+            symlinks=False,
+            ignore=None,
+            copy_function=shutil.copy2,
+            ignore_dangling_symlinks=False,
+            dirs_exist_ok=False,
+        ):
+            """Make sure the default argument is patched."""
+            if copy_function == shutil.copy2:
+                copy_function = self.copy2
+            return self._shutil_module.copytree(
+                src,
+                dst,
+                symlinks,
+                ignore,
+                copy_function,
+                ignore_dangling_symlinks,
+                dirs_exist_ok,
+            )
+
+        def move(self, src, dst, copy_function=shutil.copy2):
+            """Make sure the default argument is patched."""
+            if copy_function == shutil.copy2:
+                copy_function = self.copy2
+            return self._shutil_module.move(src, dst, copy_function)
 
     def __getattr__(self, name):
         """Forwards any non-faked calls to the standard shutil module."""


### PR DESCRIPTION
- patch away a Windows-specific optimization in shutil.copy2 to avoid calling the Windows API
- fixes #841

#### Tasks
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
