### PR TITLE
Add py.typed marker file (as defined by PEP 561)

### DIFF
--- a/pyfakefs/py.typed
+++ b/pyfakefs/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The pyfakefs package uses inline types.

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,9 @@ include_package_data = True
 [options.packages.find]
 exclude = docs
 
+[options.package_data]
+pyfakefs = py.typed
+
 [options.entry_points]
 pytest11 =
     pytest_fakefs = pyfakefs.pytest_plugin


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are still in progress.
-->

#### Describe the changes

Adds the `py.typed` file as per PEP 561. This ensures that projects that import pyfakefs can be type checked.

Note: First time working with setuptool so please make sure my change to `setup.cfg` is correct.

#### Tasks
- [x] ~~Unit tests added that reproduce the issue or prove feature is working~~ (not needed)
- [x] Fix or feature added
- [x] ~~Entry to release notes added~~ (not needed)
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] ~~For documentation changes: The Read the Docs preview builds and looks as expected~~ (not needed)
