### PR TITLE
Fix typos and add `codespell` hook to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 default_language_version:
   python: "3.10"
+
 repos:
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=wronly,afile
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Adds compatibility with PyPy 3.10 and Python 3.12.
 ### Infrastructure
 * Added pytype check for non-test modules in CI (see [#599](../../issues/599)).
 * Added tests for different pypy3 versions.
+* Added codespell hook to pre-commit
 
 ## [Version 5.2.2](https://pypi.python.org/pypi/pyfakefs/5.2.2) (2023-04-13)
 Fixes a regression in 5.2.0
@@ -126,7 +127,7 @@ Changed handling of nested fixtures and bug fixes.
 ### Fixes
 * reverted a performance optimization introduced in version 3.3.0 that
   caused hanging tests with installed torch (see [#693](../../issues/693))
-* do not use the build-in opener in `pathlib` as it may cause problems
+* do not use the built-in opener in `pathlib` as it may cause problems
   (see [#697](../../issues/697))
 * add support for path-like objects in `shutil.disk_usage`
   (see [#699](../../issues/699))
@@ -601,11 +602,11 @@ and Python 3.4 (possible bug fix releases notwithstanding).
 
 ## [Version 3.5.8](https://pypi.python.org/pypi/pyfakefs/3.5.8) (2019-06-21)
 
-Another bug-fix release that mainly fixes a regression wih Python 2 that has
+Another bug-fix release that mainly fixes a regression with Python 2 that has
 been introduced in version 3.5.3.
 
 #### Fixes
-  * regression: patching build-in `open` under Python 2 broke unit tests
+  * regression: patching built-in `open` under Python 2 broke unit tests
     (see [#469](../../issues/469))
   * fixed writing to file added with `add_real_file`
     (see [#470](../../issues/470))

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -11,7 +11,7 @@ works by patching some file system related modules and functions, specifically:
 
 - most file system related functions in the ``os`` and ``os.path`` modules
 - the ``pathlib`` module
-- the build-in ``open`` function and ``io.open``
+- the built-in ``open`` function and ``io.open``
 - ``shutil.disk_usage``
 
 Other file system related modules work with ``pyfakefs``, because they use
@@ -48,13 +48,13 @@ reasons:
 A list of Python modules that are known to not work correctly with
 ``pyfakefs`` will be collected here:
 
-`multiprocessing`_ (build-in)
+`multiprocessing`_ (built-in)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This module has several issues (related to points 1 and 3 above).
 Currently there are no plans to fix this, but this may change in case of
 sufficient demand.
 
-`subprocess`_ (build-in)
+`subprocess`_ (built-in)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 This has very similar problems to ``multiprocessing`` and cannot be used with
 ``pyfakefs`` to start a process. ``subprocess`` can either be mocked, if
@@ -69,7 +69,7 @@ function correctly. Examples that have shown this problem include `GitPython`_
 and `plumbum`_. Calling ``find_library`` also uses ``subprocess`` and does not work in
 the fake filesystem.
 
-`sqlite3`_ (build-in)
+`sqlite3`_ (built-in)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 This is a database adapter written in C, which uses the database C API to access files.
 This (and similar database adapters) will not work with ``pyfakefs``, as it will always

--- a/pyfakefs/extra_packages.py
+++ b/pyfakefs/extra_packages.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 """Imports external packages that replace or emulate internal packages.
-If the external module is not present, the build-in module is imported.
+If the external module is not present, the built-in module is imported.
 """
 
 try:

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -143,7 +143,7 @@ class FakeFile:
                 regular file type is assumed.
             contents: The contents of the filesystem object; should be a string
                 or byte object for regular files, and a dict of other
-                FakeFile or FakeDirectory objects wih the file names as
+                FakeFile or FakeDirectory objects with the file names as
                 keys for FakeDirectory objects
             filesystem: The fake filesystem where the file is created.
             encoding: If contents is a unicode string, the encoding used

--- a/pyfakefs/tests/fake_filesystem_vs_real_test.py
+++ b/pyfakefs/tests/fake_filesystem_vs_real_test.py
@@ -27,7 +27,7 @@ from pyfakefs.helpers import IS_PYPY
 
 
 def sep(path):
-    """Converts slashes in the path to the architecture's path seperator."""
+    """Converts slashes in the path to the architecture's path separator."""
     if isinstance(path, str):
         return path.replace("/", os.sep)
     return path
@@ -188,7 +188,7 @@ class FakeFilesystemVsRealTest(TestCase):
 
         method_call = f"{method_name}"
         method_call += "()" if path == () else "({path})"
-        # We only compare on the error class because the acutal error contents
+        # We only compare on the error class because the actual error contents
         # is almost always different because of the file paths.
         if _error_class(real_err) != _error_class(fake_err):
             if real_err is None:

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -265,7 +265,7 @@ class FakeFileOpenTest(FakeFileOpenTestBase):
             self.assertEqual(contents, fake_file.read())
 
     def test_overwrite_existing_file(self):
-        file_path = self.make_path("overwite")
+        file_path = self.make_path("overwrite")
         self.create_file(file_path, contents="To disappear")
         new_contents = [
             "Only these lines",

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -1582,7 +1582,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         self.assertTrue(self.os.path.exists(self.make_path("foo")))
 
     def test_mkdir_raises_if_empty_directory_name(self):
-        """mkdir raises exeption if creating directory named ''."""
+        """mkdir raises exception if creating directory named ''."""
         directory = ""
         self.assert_raises_os_error(errno.ENOENT, self.os.mkdir, directory)
 


### PR DESCRIPTION
- found via `codespell -L wronly,afile`
- add `codespell` hook to pre-commit
- ~~fix RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10'~~

<!--
Please prefix your PR title with [WIP] for PRs that are still in progress.
-->

#### Describe the changes
The related issue or a description of the bug or feature that this PR addresses.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [ ] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
