### PR TITLE
Remove debug output accidentally left in

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         include:
           - python-version: "pypy-3.7"
             os: ubuntu-latest
@@ -100,8 +100,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.9]
-        pytest-version: [3.0.0, 3.5.1, 4.0.2, 4.5.0, 5.0.1, 5.4.3, 6.0.2, 6.2.5, 7.0.1, 7.1.3, 7.2.0, 7.3.1]
+        python-version: ["3.9"]
+        pytest-version: [3.0.0, 3.5.1, 4.0.2, 4.5.0, 5.0.1, 5.4.3, 6.0.2, 6.2.5, 7.0.1, 7.1.3, 7.2.0, 7.3.1, 7.4.0]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -133,7 +133,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version:  [3.9]
+        python-version:  ["3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Changes
+* removed support for Python 3.7 (end of life)
+
 ### Fixes
 * removed a leftover debug print statement (see [#869](../../issues/869))
 * make sure tests work without HOME environment set (see [#870](../../issues/870))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ The released versions correspond to PyPI releases.
 
 ### Fixes
 * removed a leftover debug print statement (see [#869](../../issues/869))
+* make sure tests work without HOME environment set (see [#870](../../issues/870))
 
 ## [Version 5.2.3](https://pypi.python.org/pypi/pyfakefs/5.2.3) (2023-08-18)
 Fixes a rare problem on pytest shutdown.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Fixes
+* removed a leftover debug print statement (see [#869](../../issues/869))
+
 ## [Version 5.2.3](https://pypi.python.org/pypi/pyfakefs/5.2.3) (2023-08-18)
 Fixes a rare problem on pytest shutdown.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ provides some additional features:
   under root
 
 ## Compatibility
-pyfakefs works with CPython 3.7 and above, on Linux, Windows and macOS, and
+pyfakefs works with CPython 3.8 and above, on Linux, Windows and macOS, and
 with PyPy3.
 
 pyfakefs works with [pytest](http://doc.pytest.org) version 3.0.0 or above,
@@ -73,7 +73,7 @@ for more information about the limitations of pyfakefs.
 ### Continuous integration
 
 pyfakefs is currently automatically tested on Linux, macOS and Windows, with
-Python 3.7 to 3.11, and with PyPy3 on Linux, using
+Python 3.8 to 3.12, and with PyPy3 on Linux, using
 [GitHub Actions](https://github.com/pytest-dev/pyfakefs/actions).
 
 ### Running pyfakefs unit tests

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -6,7 +6,7 @@ system that mocks the Python file system modules.
 Using pyfakefs, your tests operate on a fake file system in memory without touching the real disk.
 The software under test requires no modification to work with pyfakefs.
 
-pyfakefs works with CPython 3.7 and above, on Linux, Windows and macOS,
+pyfakefs works with CPython 3.8 and above, on Linux, Windows and macOS,
 and with PyPy3.
 
 pyfakefs works with `pytest <doc.pytest.org>`__ version 3.0.0 or above by

--- a/extra_requirements.txt
+++ b/extra_requirements.txt
@@ -15,5 +15,5 @@ scandir>=1.8
 # we use the latest version to see any problems with new versions
 pandas==1.3.5; python_version == '3.7' # pyup: ignore
 pandas==2.0.3; python_version > '3.7'
-xlrd==2.0.1; python_version > '3.6'
+xlrd==2.0.1
 openpyxl==3.1.2

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -632,7 +632,6 @@ class Patcher:
     @classmethod
     def clear_fs_cache(cls) -> None:
         """Clear the module cache."""
-        print("Clearing the cache")
         cls.CACHED_MODULES = set()
         cls.FS_MODULES = {}
         cls.FS_FUNCTIONS = {}

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -815,6 +815,7 @@ class TestOtherFS(fake_filesystem_unittest.TestCase):
     def setUp(self):
         self.setUpPyfakefs()
 
+    @mock.patch.dict(os.environ, {"HOME": "/home/john"})
     def test_real_file_with_home(self):
         """Regression test for #558"""
         self.fs.is_windows_fs = os.name != "nt"

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -50,7 +49,7 @@ universal = 0
 [options]
 packages = find:
 install_requires =
-python_requires = >=3.7
+python_requires = >=3.8
 test_suite = pyfakefs.tests
 include_package_data = True
 


### PR DESCRIPTION
- fixes #869
- fix tests if HOME environment is missing
- fixes #870
- removed support for Python 3.7
  (is end of life, and behaves a bit differently so that some of the HOME-related tests failed)

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
