### PR TITLE
Simplifying `pathlib.Path` troubleshooting snippet

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -236,23 +236,27 @@ passed before the ``mocker`` fixture to ensure this:
 Pathlib.Path objects created outside of tests
 ---------------------------------------------
 An pattern which is more often seen with the increased usage of `pathlib` is the
-creation of global `pathlib.Path` objects (instead of string paths) that are used
-in the tests. As these objects are created in the real filesystem, they are not of the same
-type as faked `pathlib.Path` objects, and both will always compare as not equal,
+creation of global `pathlib.Path` objects (instead of string paths) that are imported
+into the tests. As these objects are created in the real filesystem,
+they are not of the same type as faked `pathlib.Path` objects,
+and both will always compare as not equal,
 regardless of the path they point to:
 
 .. code:: python
 
   import pathlib
 
-  FOLDER = pathlib.Path(__file__).parent
-  FILE = FOLDER / "file.csv"
+  # This Path was made in the real filesystem, before the test
+  # stands up the fake filesystem
+  FILE_PATH = pathlib.Path(__file__).parent / "file.csv"
 
+  def test_path_equality(fs):
+      # This Path was made after the fake filesystem is set up,
+      # and thus patching within pathlib is in effect
+      fake_file_path = pathlib.Path(fs.create_file(FILE_PATH).path)
 
-  def test_one(fs):
-      fake_file = pathlib.Path(fs.create_file(FILE).path)
-      assert FILE == fake_file  # fails, compares different objects
-      assert str(FILE) == str(fake_file)  # succeeds, compares the actual paths
+      assert FILE_PATH == fake_file_path  # fails, compares different objects
+      assert str(FILE_PATH) == str(fake_file_path)  # succeeds, compares the actual paths
 
 Generally, mixing objects in the real filesystem and the fake filesystem
 is problematic and better avoided.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -250,6 +250,7 @@ regardless of the path they point to:
   # stands up the fake filesystem
   FILE_PATH = pathlib.Path(__file__).parent / "file.csv"
 
+
   def test_path_equality(fs):
       # This Path was made after the fake filesystem is set up,
       # and thus patching within pathlib is in effect


### PR DESCRIPTION
#### Describe the changes

Just simplifying and making the troubleshooting snippet more intuitive.

Follow on to https://github.com/pytest-dev/pyfakefs/pull/873 for https://github.com/pytest-dev/pyfakefs/issues/872.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Entry to release notes added
- [ ] Pre-commit CI shows no errors
- [ ] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
