### PR TITLE
Removed extra create_file from troubleshooting snippet

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -235,10 +235,10 @@ passed before the ``mocker`` fixture to ensure this:
 
 Pathlib.Path objects created outside of tests
 ---------------------------------------------
-An pattern which is more often seen with the increased usage of `pathlib` is the
-creation of global `pathlib.Path` objects (instead of string paths) that are imported
+An pattern which is more often seen with the increased usage of ``pathlib`` is the
+creation of global ``pathlib.Path`` objects (instead of string paths) that are imported
 into the tests. As these objects are created in the real filesystem,
-they are not of the same type as faked `pathlib.Path` objects,
+they are not of the same type as faked ``pathlib.Path`` objects,
 and both will always compare as not equal,
 regardless of the path they point to:
 
@@ -246,15 +246,18 @@ regardless of the path they point to:
 
   import pathlib
 
+  import pytest
+
   # This Path was made in the real filesystem, before the test
   # stands up the fake filesystem
   FILE_PATH = pathlib.Path(__file__).parent / "file.csv"
 
 
-  def test_path_equality(fs):
+  @pytest.mark.usefixtures("fs")
+  def test_path_equality():
       # This Path was made after the fake filesystem is set up,
       # and thus patching within pathlib is in effect
-      fake_file_path = pathlib.Path(fs.create_file(FILE_PATH).path)
+      fake_file_path = pathlib.Path(str(FILE_PATH))
 
       assert FILE_PATH == fake_file_path  # fails, compares different objects
       assert str(FILE_PATH) == str(fake_file_path)  # succeeds, compares the actual paths

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -238,7 +238,7 @@ Pathlib.Path objects created outside of tests
 An pattern which is more often seen with the increased usage of ``pathlib`` is the
 creation of global ``pathlib.Path`` objects (instead of string paths) that are imported
 into the tests. As these objects are created in the real filesystem,
-they are not of the same type as faked ``pathlib.Path`` objects,
+they do not have the same attributes as fake ``pathlib.Path`` objects,
 and both will always compare as not equal,
 regardless of the path they point to:
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -246,15 +246,12 @@ regardless of the path they point to:
 
   import pathlib
 
-  import pytest
-
   # This Path was made in the real filesystem, before the test
   # stands up the fake filesystem
   FILE_PATH = pathlib.Path(__file__).parent / "file.csv"
 
 
-  @pytest.mark.usefixtures("fs")
-  def test_path_equality():
+  def test_path_equality(fs):
       # This Path was made after the fake filesystem is set up,
       # and thus patching within pathlib is in effect
       fake_file_path = pathlib.Path(str(FILE_PATH))


### PR DESCRIPTION
- Noticed syntax highlighting needed an update
    - Single backtick means italics, double backtick means code syntax
- Fixed wording from "type" to "attributes"
- Realized to make the point in the code snippet about `Path`, don't need `create_file` at all

For https://github.com/pytest-dev/pyfakefs/issues/872