### PR TITLE
Add a note about setUpClassPyfakefs usage

### DIFF
--- a/.github/workflows/dockertests.yml
+++ b/.github/workflows/dockertests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         docker-image: [debian, fedora, ubuntu, redhat]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup docker container
       run: |
         docker build -t pyfakefs -f $GITHUB_WORKSPACE/.github/workflows/dockerfiles/Dockerfile_${{ matrix.docker-image }} . --build-arg github_repo=$GITHUB_REPOSITORY --build-arg github_branch=$GITHUB_REF_NAME

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: [ '3.10' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
@@ -35,7 +35,7 @@ jobs:
             os: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -77,12 +77,12 @@ jobs:
         fi
       shell: bash
     - name: Install extra dependencies
-      if: ${{ matrix.python-version != '3.12-dev' }}
+      if: ${{ matrix.python-version != '3.12-dev' && matrix.python-version != 'pypy-3.10' }}
       run: |
         pip install -r extra_requirements.txt
       shell: bash
     - name: Run unit tests with extra packages as non-root user
-      if: ${{ matrix.python-version != '3.12-dev' }}
+      if: ${{ matrix.python-version != '3.12-dev' && matrix.python-version != 'pypy-3.10' }}
       run: |
         python -m pyfakefs.tests.all_tests
       shell: bash
@@ -103,7 +103,7 @@ jobs:
         python-version: ["3.9"]
         pytest-version: [3.0.0, 3.5.1, 4.0.2, 4.5.0, 5.0.1, 5.4.3, 6.0.2, 6.2.5, 7.0.1, 7.1.3, 7.2.0, 7.3.1, 7.4.0]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -135,7 +135,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version:  ["3.10"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -29,7 +29,7 @@ Unittest module classes
 -----------------------
 
 .. autoclass:: pyfakefs.fake_filesystem_unittest.TestCaseMixin
-    :members: fs, setUpPyfakefs, pause, resume
+    :members: fs, setUpPyfakefs, setUpClassPyfakefs, pause, resume
 
 .. autoclass:: pyfakefs.fake_filesystem_unittest.TestCase
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -105,7 +105,8 @@ method ``setUpClassPyfakefs`` instead:
             self.assertTrue(os.path.exists(file_path))
 
 .. note:: This feature cannot be used with a Python version before Python 3.8 due to
-  a missing feature in ``unittest``.
+  a missing feature in ``unittest``. If you use ``pytest`` for running tests using this feature,
+  you need to have at least ``pytest`` version 6.2 due to an issue in earlier versions.
 
 .. caution:: If this is used, any changes made in the fake filesystem inside a test
   will remain there for all following tests in the test class, if they are not reverted

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -207,7 +207,7 @@ class TestCaseMixin:
     modules by fake implementations.
 
     Attributes:
-        additional_skip_names: names of modules inside of which no module
+        additional_skip_names: names of modules where no module
             replacement shall be performed, in addition to the names in
             :py:attr:`fake_filesystem_unittest.Patcher.SKIPNAMES`.
             Instead of the module names, the modules themselves may be used.
@@ -220,7 +220,7 @@ class TestCaseMixin:
             fully qualified patched module names. Can be used to add patching
             of modules not provided by `pyfakefs`.
 
-    If you specify some of these attributes here and you have DocTests,
+    If you specify some of these attributes here, and you have DocTests,
     consider also specifying the same arguments to :py:func:`load_doctests`.
 
     Example usage in derived test classes::
@@ -322,6 +322,8 @@ class TestCaseMixin:
         :py:func:`setUpPyfakefs` in the same class will not work correctly.
 
         .. note:: This method is only available from Python 3.8 onwards.
+        .. note:: If using `pytest` as testrunner, you need at least pytest 6.2
+            for this method to work.
         """
         if sys.version_info < (3, 8):
             raise NotImplementedError(
@@ -516,7 +518,7 @@ class Patcher:
     ) -> None:
         """
         Args:
-            additional_skip_names: names of modules inside of which no module
+            additional_skip_names: names of modules where no module
                 replacement shall be performed, in addition to the names in
                 :py:attr:`fake_filesystem_unittest.Patcher.SKIPNAMES`.
                 Instead of the module names, the modules themselves
@@ -1021,7 +1023,7 @@ class Patcher:
 class Pause:
     """Simple context manager that allows to pause/resume patching the
     filesystem. Patching is paused in the context manager, and resumed after
-    going out of it's scope.
+    going out of its scope.
     """
 
     def __init__(self, caller: Union[Patcher, TestCaseMixin, FakeFilesystem]):

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -460,8 +460,7 @@ class FakeOsModule:
         `path`.
 
         Args:
-            path: File path, file descriptor or path-like object (for
-                Python >= 3.6).
+            path: File path, file descriptor or path-like object.
             attribute: (str or bytes) The attribute name.
             follow_symlinks: (bool) If True (the default), symlinks in the
                 path are traversed.
@@ -487,8 +486,8 @@ class FakeOsModule:
         """Return a list of the extended filesystem attributes on `path`.
 
         Args:
-            path: File path, file descriptor or path-like object (for
-                Python >= 3.6). If None, the current directory is used.
+            path: File path, file descriptor or path-like object.
+               If None, the current directory is used.
             follow_symlinks: (bool) If True (the default), symlinks in the
                 path are traversed.
 
@@ -512,11 +511,10 @@ class FakeOsModule:
     def removexattr(
         self, path: AnyStr, attribute: AnyString, *, follow_symlinks: bool = True
     ) -> None:
-        """Removes the extended filesystem attribute attribute from `path`.
+        """Removes the extended filesystem attribute from `path`.
 
         Args:
-            path: File path, file descriptor or path-like object (for
-                Python >= 3.6).
+            path: File path, file descriptor or path-like object
             attribute: (str or bytes) The attribute name.
             follow_symlinks: (bool) If True (the default), symlinks in the
                 path are traversed.
@@ -546,8 +544,7 @@ class FakeOsModule:
         `path`.
 
         Args:
-            path: File path, file descriptor or path-like object (for
-                Python >= 3.6).
+            path: File path, file descriptor or path-like object.
             attribute: The attribute name (str or bytes).
             value: (byte-like) The value to be set.
             follow_symlinks: (bool) If True (the default), symlinks in the

--- a/pyfakefs/fake_path.py
+++ b/pyfakefs/fake_path.py
@@ -351,8 +351,8 @@ class FakePathModule:
         """Return whether path1 and path2 point to the same file.
 
         Args:
-            path1: first file path or path object (Python >=3.6)
-            path2: second file path or path object (Python >=3.6)
+            path1: first file path or path object
+            path2: second file path or path object
 
         Raises:
             OSError: if one of the paths does not point to an existing

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -579,10 +579,9 @@ class FakePath(pathlib.Path):
             Args:
                 strict: If False (default) no exception is raised if the path
                     does not exist.
-                    New in Python 3.6.
 
             Raises:
-                OSError: if the path doesn't exist (strict=True or Python < 3.6)
+                OSError: if the path doesn't exist (strict=True)
             """
             if sys.version_info >= (3, 6):
                 if strict is None:

--- a/pyfakefs/pytest_tests/pytest_fixture_param_test.py
+++ b/pyfakefs/pytest_tests/pytest_fixture_param_test.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 # Example for a test using a custom pytest fixture with an argument to Patcher
-# Needs Python >= 3.6
 import os
 
 import pytest

--- a/pyfakefs/pytest_tests/pytest_fixture_test.py
+++ b/pyfakefs/pytest_tests/pytest_fixture_test.py
@@ -11,7 +11,6 @@
 # limitations under the License.
 
 # Example for a test using a custom pytest fixture with an argument to Patcher
-# Needs Python >= 3.6
 
 import pytest
 

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -761,10 +761,6 @@ class PathlibTest(TestCase):
 
 
 class TestDeprecationSuppression(fake_filesystem_unittest.TestCase):
-    @unittest.skipIf(
-        sys.version_info[1] == 6,
-        "Test fails for Python 3.6 for unknown reason",
-    )
     def test_no_deprecation_warning(self):
         """Ensures that deprecation warnings are suppressed during module
         lookup, see #542.

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -5261,8 +5261,8 @@ class FakeScandirTest(FakeOsModuleTestBase):
             self.assertEqual(file_stat.st_dev, self.dir_entries[5].stat().st_dev)
 
     @unittest.skipIf(
-        sys.version_info < (3, 6) or not use_builtin_scandir,
-        "Path-like objects have been introduced in Python 3.6",
+        not use_builtin_scandir,
+        "Path-like objects not available in scandir package",
     )
     def test_path_like(self):
         self.assertTrue(isinstance(self.dir_entries[0], os.PathLike))

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -776,8 +776,8 @@ class RealPathlibPathFileOperationTest(FakePathlibPathFileOperationTest):
 
 
 class FakePathlibUsageInOsFunctionsTest(RealPathlibTestCase):
-    """Test that many os / os.path functions accept a path-like object
-    since Python 3.6. The functionality of these functions is tested
+    """Test that many `os` / `os.path` functions accept a path-like object.
+    The functionality of these functions is tested
     elsewhere, we just check that they accept a fake path object as an
     argument.
     """


### PR DESCRIPTION
- if used with pytest, pytest >= 6.2 is needed (see #885)
- also remove obsolete Python 3.6 references

#### Tasks
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
