### PR TITLE
Fix pathlib.Path.mkdir() with unmounted path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ The released versions correspond to PyPI releases.
 ### Fixes
 * removed a leftover debug print statement (see [#869](../../issues/869))
 * make sure tests work without HOME environment set (see [#870](../../issues/870))
+* automount drive or UNC path under Windows if needed for `pathlib.Path.mkdir()`
+  (see [#890](../../issues/890))
 
 ## [Version 5.2.3](https://pypi.python.org/pypi/pyfakefs/5.2.3) (2023-08-18)
 Fixes a rare problem on pytest shutdown.

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -2642,12 +2642,16 @@ class FakeFilesystem:
 
         if self.is_windows_fs:
             dir_name = self.absnormpath(dir_name)
-        parent_dir, _ = self.splitpath(dir_name)
+        parent_dir, rest = self.splitpath(dir_name)
         if parent_dir:
             base_dir = self.normpath(parent_dir)
             ellipsis = matching_string(parent_dir, self.path_separator + "..")
             if parent_dir.endswith(ellipsis) and not self.is_windows_fs:
                 base_dir, dummy_dotdot, _ = parent_dir.partition(ellipsis)
+            if self.is_windows_fs and not rest and not self.exists(base_dir):
+                # under Windows, the parent dir may be a drive or UNC path
+                # which has to be mounted
+                self._auto_mount_drive_if_needed(parent_dir)
             if not self.exists(base_dir):
                 self.raise_os_error(errno.ENOENT, base_dir)
 

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -706,6 +706,18 @@ class FakePathlibPathFileOperationTest(RealPathlibTestCase):
             errno.EEXIST, self.path(file_name).mkdir, exist_ok=True
         )
 
+    @unittest.skipIf(not is_windows, "Windows specific behavior")
+    def test_mkdir_with_automount_unc_path(self):
+        self.skip_real_fs()
+        self.path(r"\\test\unc\foo").mkdir(parents=True)
+        self.assertTrue(self.path(r"\\test\unc\foo").exists())
+
+    @unittest.skipIf(not is_windows, "Windows specific behavior")
+    def test_mkdir_with_automount_drive(self):
+        self.skip_real_fs()
+        self.path(r"d:\foo\bar").mkdir(parents=True)
+        self.assertTrue(self.path(r"d:\foo\bar").exists())
+
     def test_rmdir(self):
         dir_name = self.make_path("foo", "bar")
         self.create_dir(dir_name)


### PR DESCRIPTION
- automount drive or UNC path under Windows if needed in FakeFilesystem.makedir() (used by Path.mkdir)
- fixes #890

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
