### PR TITLE
Fix patching open for Python 3.12

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
         include:
           - python-version: "pypy-3.7"
             os: ubuntu-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,15 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Changes
+* add official support for Python 3.12
+
 ### Fixes
 * removed a leftover debug print statement (see [#869](../../issues/869))
 * make sure tests work without HOME environment set (see [#870](../../issues/870))
 * automount drive or UNC path under Windows if needed for `pathlib.Path.mkdir()`
   (see [#890](../../issues/890))
+* adapt patching `io.open` to work with Python 3.12 (see [#836](../../issues/836))
 
 ## [Version 5.2.3](https://pypi.python.org/pypi/pyfakefs/5.2.3) (2023-08-18)
 Fixes a rare problem on pytest shutdown.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ for more information about the limitations of pyfakefs.
 ### Continuous integration
 
 pyfakefs is currently automatically tested on Linux, macOS and Windows, with
-Python 3.7 to 3.11, and with PyPy3 on Linux, using
+Python 3.7 to 3.12, and with PyPy3 on Linux, using
 [GitHub Actions](https://github.com/pytest-dev/pyfakefs/actions).
 
 ### Running pyfakefs unit tests

--- a/pyfakefs/fake_io.py
+++ b/pyfakefs/fake_io.py
@@ -95,9 +95,16 @@ class FakeIoModule:
         # specific modules; instead we check if the caller is a skipped
         # module (should work in most cases)
         stack = traceback.extract_stack(limit=2)
+        # handle the case that we try to call the original `open_code`
+        # and get here instead (since Python 3.12)
+        from_open_code = (
+            sys.version_info >= (3, 12)
+            and stack[0].name == "open_code"
+            and stack[0].line == "return self._io_module.open_code(path)"
+        )
         module_name = os.path.splitext(stack[0].filename)[0]
         module_name = module_name.replace(os.sep, ".")
-        if any(
+        if from_open_code or any(
             [
                 module_name == sn or module_name.endswith("." + sn)
                 for sn in self.skip_names

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: POSIX


### PR DESCRIPTION
- add patching _io, as this is used for io
- add workaround for calling the real open_code (does not work yet under Windows)
- add Python 3.12 to supported Python versions
- fixes #836

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [ ] Pre-commit CI shows no errors
- [ ] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
