### PR TITLE
Add patching getcwd/getcwdb for nt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,14 +11,15 @@ The released versions correspond to PyPI releases.
 * make sure tests work without HOME environment set (see [#870](../../issues/870))
 * automount drive or UNC path under Windows if needed for `pathlib.Path.mkdir()`
   (see [#890](../../issues/890))
-* adapt patching `io.open` to work with Python 3.12 (see [#836](../../issues/836))
+* adapt patching `io.open` and `io.open_code` to work with Python 3.12
+  (see [#836](../../issues/836) and [#892](../../issues/892))
 
 ## [Version 5.2.3](https://pypi.python.org/pypi/pyfakefs/5.2.3) (2023-08-18)
 Fixes a rare problem on pytest shutdown.
 
 ### Fixes
 * Clear the patched module cache on session shutdown (pytest only)
-  (see [#866](../../issues/866)). Added a class method `Patcher.cler_fs_cache`
+  (see [#866](../../issues/866)). Added a class method `Patcher.clear_fs_cache`
   for clearing the patched module cache.
 
 ## [Version 5.2.3](https://pypi.python.org/pypi/pyfakefs/5.2.3) (2023-07-10)

--- a/pyfakefs/fake_path.py
+++ b/pyfakefs/fake_path.py
@@ -39,6 +39,7 @@ from pyfakefs.helpers import (
     make_string_path,
     to_string,
     matching_string,
+    to_bytes,
 )
 
 if TYPE_CHECKING:
@@ -506,6 +507,14 @@ if sys.platform == "win32":
 
             self.filesystem = filesystem
             self.nt_module: Any = nt
+
+        def getcwd(self) -> str:
+            """Return current working directory."""
+            return to_string(self.filesystem.cwd)
+
+        def getcwdb(self) -> bytes:
+            """Return current working directory as bytes."""
+            return to_bytes(self.filesystem.cwd)
 
         if sys.version_info >= (3, 12):
 

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -805,7 +805,6 @@ class AutoPatchOpenCodeTestCase(fake_filesystem_unittest.TestCase):
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
 
-    @unittest.skipIf(sys.platform == "win32", "Not yet working under Windows")
     def test_exec_module_in_fake_fs(self):
         self.fs.create_file("/foo/bar.py", contents="print('hello')")
         with redirect_stdout(StringIO()) as stdout:


### PR DESCRIPTION
- fixes Windows problem if called from fspath, if the real current drive is not C:
- fixes test for #892 under Windows

Turns out that the fix for #892 actually worked, but with the concrete test code it failed under Windows in the CI because the current working dir was on another drive than C:. 
The notation with a slash (or backslash) at the beginning of the path under Windows means that it uses the current drive. On creating the path, the current drive in the fake fs was used (which is C: by default) by calling `getcwd` in the fake fs, but `importlib.util.spec_from_file_location` used `os.fspath` that under Windows uses `nt.getcwd` instead of `os.getcwd`, which was not patched.
Patching `nt.getcwd` fixes this.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
