### PR TITLE
Replace setattr and getattr calls with __dict__ manipulations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ The released versions correspond to PyPI releases.
 ### Fixes
 * fixes the problem that filesystem patching was still active in the pytest
   logreport phase (see [#904](../../issues/904))
-* Restores compatability with PyTorch 2.0 and above, as well as with other
+* Restores compatibility with PyTorch 2.0 and above, as well as with other
   classes that have custom __setattr__ methods (see [#905](../../pull/905)).
 
 ## [Version 5.3.0](https://pypi.python.org/pypi/pyfakefs/5.3.0) (2023-10-11)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,8 @@ The released versions correspond to PyPI releases.
 ### Fixes
 * fixes the problem that filesystem patching was still active in the pytest
   logreport phase (see [#904](../../issues/904))
-* Restores compatability with PyTorch 2.0 and above, as well as with other classes that
-  have custom __setattr__ methods (see [#905](../../issues/905)).
+* Restores compatability with PyTorch 2.0 and above, as well as with other
+  classes that have custom __setattr__ methods (see [#905](../../pull/905)).
 
 ## [Version 5.3.0](https://pypi.python.org/pypi/pyfakefs/5.3.0) (2023-10-11)
 Adds official support for Python 3.12.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ The released versions correspond to PyPI releases.
 ### Fixes
 * fixes the problem that filesystem patching was still active in the pytest
   logreport phase (see [#904](../../issues/904))
+* Restores compatability with PyTorch 2.0 and above, as well as with other classes that
+  have custom __setattr__ methods (see [#905](../../issues/905)).
 
 ## [Version 5.3.0](https://pypi.python.org/pypi/pyfakefs/5.3.0) (2023-10-11)
 Adds official support for Python 3.12.

--- a/pyfakefs/mox3_stubout.py
+++ b/pyfakefs/mox3_stubout.py
@@ -61,14 +61,9 @@ class StubOutForTesting:
         This method supports the case where attr_name is a staticmethod or a
         classmethod of obj.
 
-        Notes:
-          - If obj is an instance, then it is its class that will actually be
-            stubbed. Note that the method Set() does not do that: if obj is
-            an instance, it (and not its class) will be stubbed.
-          - The stubbing is using the builtin getattr and setattr. So, the
-            __get__ and __set__ will be called when stubbing (TODO: A better
-            idea would probably be to manipulate obj.__dict__ instead of
-            getattr() and setattr()).
+        If obj is an instance, then it is its class that will actually be
+        stubbed. Note that the method Set() does not do that: if obj is an
+        instance, it (and not its class) will be stubbed.
 
         Raises AttributeError if the attribute cannot be found.
         """

--- a/pyfakefs/mox3_stubout.py
+++ b/pyfakefs/mox3_stubout.py
@@ -24,7 +24,64 @@ Therefore just this file was forked from mox3 and incorporated
 into pyfakefs.
 """
 
+from enum import Enum, auto
+from typing import Any
 import inspect
+
+
+class AccessMethod(Enum):
+    GETATTR = auto()
+    DICT = auto()
+    SLOT = auto()
+
+
+def universal_getattr(obj: Any, attr_name: str) -> tuple[Any, AccessMethod]:
+    """Get an attribute's value in a universal way
+
+    Can read any normal attributes, as well as attributes specified in
+    custom `__getattr__` methods, or stored in `obj.__dict__` or `obj.__slot__`.
+    Returns the attribute's value and the method used to access it, which can
+    then be used with the `set_attribute_safely` method to set it if needed.
+
+    Warning: If the AccessMethod returned is AccessMethod.GETATTR, if the attribute
+    has wrappers, such as staticmethod or classmethod, these will be stripped.
+    """
+    try:
+        attr_value = getattr(obj, attr_name)
+        access_method = AccessMethod.GETATTR
+    except AttributeError as e:
+        if hasattr(obj, '__dict__') and attr_name in obj.__dict__:
+            attr_value = obj.__dict__[attr_name]
+            access_method = AccessMethod.DICT
+        elif hasattr(obj, '__slot__') and attr_name in obj.__slot__:
+            attr_value = obj.__slot__[attr_name]
+            access_method = AccessMethod.SLOT
+        else:
+            raise e
+
+    return attr_value, access_method
+
+
+def universal_setattr(obj: Any, attr_name: str, attr_value: Any, access_method: AccessMethod):
+    """Set an attribute's value in a universal way
+
+    Can set any normal attributes, as well as attributes stored in `obj.__dict__`
+    or `obj.__slot__`, depending on the value of `access_method`.
+    """
+    if access_method == AccessMethod.GETATTR:
+        setattr(obj, attr_name, attr_value)
+    elif access_method == AccessMethod.DICT:
+        try:
+            obj.__dict__[attr_name] = attr_value
+        except KeyError:
+            raise AttributeError(f"Attribute {attr_name} not found in __dict__")
+    elif access_method == AccessMethod.SLOT:
+        try:
+            obj.__slot__[attr_name] = attr_value
+        except KeyError:
+            raise AttributeError(f"Attribute {attr_name} not found in __slot__")
+    else:
+        raise NotImplementedError(f'Unknown {access_method = } has not been implemented')
 
 
 class StubOutForTesting:
@@ -67,15 +124,18 @@ class StubOutForTesting:
 
         Raises AttributeError if the attribute cannot be found.
         """
+        orig_obj = None
+        orig_attr = None
+        access_method = None
+
         if inspect.ismodule(obj) or (
             not inspect.isclass(obj) and attr_name in obj.__dict__
         ):
             orig_obj = obj
-            if attr_name in obj.__dict__:
-                orig_attr = obj.__dict__[attr_name]
-            else:
-                orig_attr = None
-
+            try:
+                orig_attr, access_method = universal_getattr(obj, attr_name)
+            except AttributeError:
+                pass
         else:
             if not inspect.isclass(obj):
                 mro = list(inspect.getmro(obj.__class__))
@@ -84,20 +144,18 @@ class StubOutForTesting:
 
             mro.reverse()
 
-            orig_attr = None
-
             for cls in mro:
                 try:
                     orig_obj = cls
-                    orig_attr = obj.__dict__[attr_name]
-                except KeyError:
+                    orig_attr, access_method = universal_getattr(obj, attr_name)
+                except AttributeError:
                     continue
 
-        if orig_attr is None:
+        if orig_obj is None or access_method is None:
             raise AttributeError("Attribute not found.")
 
-        self.stubs.append((orig_obj, attr_name, orig_attr))
-        orig_obj.__dict__[attr_name] = new_attr
+        self.stubs.append((orig_obj, attr_name, orig_attr, access_method))
+        universal_setattr(orig_obj, attr_name, new_attr, access_method)
 
     def smart_unset_all(self):
         """Reverses all the SmartSet() calls.
@@ -108,8 +166,8 @@ class StubOutForTesting:
         """
         self.stubs.reverse()
 
-        for obj, attr_name, old_attr in self.stubs:
-            obj.__dict__[attr_name] = old_attr
+        for obj, attr_name, old_attr, access_method in self.stubs:
+            universal_setattr(obj, attr_name, old_attr, access_method)
 
         self.stubs = []
 
@@ -125,17 +183,21 @@ class StubOutForTesting:
         This method supports the case where child_name is a staticmethod or a
         classmethod of parent.
         """
-        old_child = getattr(parent, child_name)
+        # Get the child value
+        old_child, access_method = universal_getattr(parent, child_name)
 
-        old_attribute = parent.__dict__.get(child_name)
-        if old_attribute is not None:
-            if isinstance(old_attribute, staticmethod):
-                old_child = staticmethod(old_child)
-            elif isinstance(old_attribute, classmethod):
-                old_child = classmethod(old_child.__func__)
+        # Try getting it again directly from the __dict__, to preserve any decorators
+        if child_name in parent.__dict__:
+            old_attribute = parent.__dict__.get(child_name)
 
-        self.cache.append((parent, old_child, child_name))
-        parent.__dict__[child_name] = new_child
+            if old_attribute is not None:
+                if isinstance(old_attribute, staticmethod):
+                    old_child = staticmethod(old_child)
+                elif isinstance(old_attribute, classmethod):
+                    old_child = classmethod(old_child.__func__)
+
+        self.cache.append((parent, old_child, child_name, access_method))
+        universal_setattr(parent, child_name, new_child, access_method)
 
     def unset_all(self):
         """Reverses all the Set() calls.
@@ -149,6 +211,6 @@ class StubOutForTesting:
         # undone)
         self.cache.reverse()
 
-        for parent, old_child, child_name in self.cache:
-            parent.__dict__[child_name] = old_child
+        for parent, old_child, child_name, access_method in self.cache:
+            universal_setattr(parent, child_name, old_child, access_method)
         self.cache = []

--- a/pyfakefs/mox3_stubout.py
+++ b/pyfakefs/mox3_stubout.py
@@ -71,7 +71,10 @@ class StubOutForTesting:
             not inspect.isclass(obj) and attr_name in obj.__dict__
         ):
             orig_obj = obj
-            orig_attr = obj.__dict__[attr_name]
+            if attr_name in obj.__dict__:
+                orig_attr = obj.__dict__[attr_name]
+            else:
+                orig_attr = None
 
         else:
             if not inspect.isclass(obj):

--- a/pyfakefs/mox3_stubout.py
+++ b/pyfakefs/mox3_stubout.py
@@ -24,64 +24,7 @@ Therefore just this file was forked from mox3 and incorporated
 into pyfakefs.
 """
 
-from enum import Enum, auto
-from typing import Any
 import inspect
-
-
-class AccessMethod(Enum):
-    GETATTR = auto()
-    DICT = auto()
-    SLOT = auto()
-
-
-def universal_getattr(obj: Any, attr_name: str) -> tuple[Any, AccessMethod]:
-    """Get an attribute's value in a universal way
-
-    Can read any normal attributes, as well as attributes specified in
-    custom `__getattr__` methods, or stored in `obj.__dict__` or `obj.__slot__`.
-    Returns the attribute's value and the method used to access it, which can
-    then be used with the `set_attribute_safely` method to set it if needed.
-
-    Warning: If the AccessMethod returned is AccessMethod.GETATTR, if the attribute
-    has wrappers, such as staticmethod or classmethod, these will be stripped.
-    """
-    try:
-        attr_value = getattr(obj, attr_name)
-        access_method = AccessMethod.GETATTR
-    except AttributeError as e:
-        if hasattr(obj, '__dict__') and attr_name in obj.__dict__:
-            attr_value = obj.__dict__[attr_name]
-            access_method = AccessMethod.DICT
-        elif hasattr(obj, '__slot__') and attr_name in obj.__slot__:
-            attr_value = obj.__slot__[attr_name]
-            access_method = AccessMethod.SLOT
-        else:
-            raise e
-
-    return attr_value, access_method
-
-
-def universal_setattr(obj: Any, attr_name: str, attr_value: Any, access_method: AccessMethod):
-    """Set an attribute's value in a universal way
-
-    Can set any normal attributes, as well as attributes stored in `obj.__dict__`
-    or `obj.__slot__`, depending on the value of `access_method`.
-    """
-    if access_method == AccessMethod.GETATTR:
-        setattr(obj, attr_name, attr_value)
-    elif access_method == AccessMethod.DICT:
-        try:
-            obj.__dict__[attr_name] = attr_value
-        except KeyError:
-            raise AttributeError(f"Attribute {attr_name} not found in __dict__")
-    elif access_method == AccessMethod.SLOT:
-        try:
-            obj.__slot__[attr_name] = attr_value
-        except KeyError:
-            raise AttributeError(f"Attribute {attr_name} not found in __slot__")
-    else:
-        raise NotImplementedError(f'Unknown {access_method = } has not been implemented')
 
 
 class StubOutForTesting:
@@ -124,18 +67,15 @@ class StubOutForTesting:
 
         Raises AttributeError if the attribute cannot be found.
         """
-        orig_obj = None
-        orig_attr = None
-        access_method = None
-
         if inspect.ismodule(obj) or (
             not inspect.isclass(obj) and attr_name in obj.__dict__
         ):
             orig_obj = obj
-            try:
-                orig_attr, access_method = universal_getattr(obj, attr_name)
-            except AttributeError:
-                pass
+            if attr_name in obj.__dict__:
+                orig_attr = obj.__dict__[attr_name]
+            else:
+                orig_attr = None
+
         else:
             if not inspect.isclass(obj):
                 mro = list(inspect.getmro(obj.__class__))
@@ -144,18 +84,20 @@ class StubOutForTesting:
 
             mro.reverse()
 
+            orig_attr = None
+
             for cls in mro:
                 try:
                     orig_obj = cls
-                    orig_attr, access_method = universal_getattr(obj, attr_name)
-                except AttributeError:
+                    orig_attr = obj.__dict__[attr_name]
+                except KeyError:
                     continue
 
-        if orig_obj is None or access_method is None:
+        if orig_attr is None:
             raise AttributeError("Attribute not found.")
 
-        self.stubs.append((orig_obj, attr_name, orig_attr, access_method))
-        universal_setattr(orig_obj, attr_name, new_attr, access_method)
+        self.stubs.append((orig_obj, attr_name, orig_attr))
+        orig_obj.__dict__[attr_name] = new_attr
 
     def smart_unset_all(self):
         """Reverses all the SmartSet() calls.
@@ -166,8 +108,8 @@ class StubOutForTesting:
         """
         self.stubs.reverse()
 
-        for obj, attr_name, old_attr, access_method in self.stubs:
-            universal_setattr(obj, attr_name, old_attr, access_method)
+        for obj, attr_name, old_attr in self.stubs:
+            obj.__dict__[attr_name] = old_attr
 
         self.stubs = []
 
@@ -183,21 +125,17 @@ class StubOutForTesting:
         This method supports the case where child_name is a staticmethod or a
         classmethod of parent.
         """
-        # Get the child value
-        old_child, access_method = universal_getattr(parent, child_name)
+        old_child = getattr(parent, child_name)
 
-        # Try getting it again directly from the __dict__, to preserve any decorators
-        if child_name in parent.__dict__:
-            old_attribute = parent.__dict__.get(child_name)
+        old_attribute = parent.__dict__.get(child_name)
+        if old_attribute is not None:
+            if isinstance(old_attribute, staticmethod):
+                old_child = staticmethod(old_child)
+            elif isinstance(old_attribute, classmethod):
+                old_child = classmethod(old_child.__func__)
 
-            if old_attribute is not None:
-                if isinstance(old_attribute, staticmethod):
-                    old_child = staticmethod(old_child)
-                elif isinstance(old_attribute, classmethod):
-                    old_child = classmethod(old_child.__func__)
-
-        self.cache.append((parent, old_child, child_name, access_method))
-        universal_setattr(parent, child_name, new_child, access_method)
+        self.cache.append((parent, old_child, child_name))
+        parent.__dict__[child_name] = new_child
 
     def unset_all(self):
         """Reverses all the Set() calls.
@@ -211,6 +149,6 @@ class StubOutForTesting:
         # undone)
         self.cache.reverse()
 
-        for parent, old_child, child_name, access_method in self.cache:
-            universal_setattr(parent, child_name, old_child, access_method)
+        for parent, old_child, child_name in self.cache:
+            parent.__dict__[child_name] = old_child
         self.cache = []


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are still in progress.
-->

#### Describe the changes
Change the `setattr` and `getattr` calls in `pyfakefs/mox3_stubout.py` to directly access the objects `__dict__` attribute. I did this because I was having trouble using pyfakefs in a large codebase that also used PyTorch – which I tracked down to custom `__setattr__` methods [found here](https://github.com/pytorch/pytorch/blob/7bcf7da3a268b435777fe87c7794c382f444e86d/torch/_dynamo/config_utils.py#L68-L74) (among other places).

I saw the comment in `pyfakefs/mox3_stubout.py` mentioning that a switch to manipulating the `__dict__` attribute directly had been considered, and that it would even resolve the special case with static methods losing their `staticmethod` wrapper when accessing them with `getattr`, so I went ahead and made that change throughout the file.

I'm not sure if this will break pyfakefs for other use cases, but it fixed it for me, so I figured I'd make a pull request :)

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [ ] Pre-commit CI shows no errors
- [ ] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
