### PR TITLE
Use a separate fake module for _io

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -77,13 +77,15 @@ jobs:
         fi
       shell: bash
     - name: Install extra dependencies
-      if: ${{ matrix.python-version != '3.12-dev' && matrix.python-version != 'pypy-3.10' }}
+      if: ${{ matrix.python-version != 'pypy-3.10' }}
       run: |
         pip install -r extra_requirements.txt
+        pip install zstandard cffi  # needed to test #910
       shell: bash
     - name: Run unit tests with extra packages as non-root user
-      if: ${{ matrix.python-version != '3.12-dev' && matrix.python-version != 'pypy-3.10' }}
+      if: ${{ matrix.python-version != 'pypy-3.10' }}
       run: |
+        export PYTHON_ZSTANDARD_IMPORT_POLICY=cffi  # needed to test #910
         python -m pyfakefs.tests.all_tests
       shell: bash
     - name: Run performance tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 # pyfakefs Release Notes
 The released versions correspond to PyPI releases.
 
+## Unreleased
+
+### Fixes
+* fixed a problem with patching `_io` under Python 3.12 (see [#910](../../issues/910))
+
 ## [Version 5.3.1](https://pypi.python.org/pypi/pyfakefs/5.3.0) (2023-11-15)
 Mostly a bugfix release.
 

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -656,7 +656,7 @@ class Patcher:
         }
         if IS_PYPY or sys.version_info >= (3, 12):
             # in PyPy and later cpython versions, the module is referenced as _io
-            self._fake_module_classes["_io"] = fake_io.FakeIoModule
+            self._fake_module_classes["_io"] = fake_io.FakeIoModule2
         if sys.platform == "win32":
             self._fake_module_classes["nt"] = fake_path.FakeNtModule
         else:

--- a/pyfakefs/fake_io.py
+++ b/pyfakefs/fake_io.py
@@ -15,6 +15,7 @@
 """ Uses :py:class:`FakeIoModule` to provide a
     fake ``io`` module replacement.
 """
+import _io  # pytype: disable=import-error
 import io
 import os
 import sys
@@ -148,6 +149,18 @@ class FakeIoModule:
     def __getattr__(self, name):
         """Forwards any unfaked calls to the standard io module."""
         return getattr(self._io_module, name)
+
+
+class FakeIoModule2(FakeIoModule):
+    """Similar to ``FakeIoModule``, but fakes `_io` instead of `io`."""
+
+    def __init__(self, filesystem: "FakeFilesystem"):
+        """
+        Args:
+            filesystem: FakeFilesystem used to provide file system information.
+        """
+        super().__init__(filesystem)
+        self._io_module = _io
 
 
 if sys.platform != "win32":


### PR DESCRIPTION
- in Python 3.12, _io is not a simple alias for io
- fixes #910

I have run this without the fix in place, and the Python 3.12 tests failed on all platforms.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
