### PR TITLE
Fix separator mismatch with Linux emulated under Windows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ The released versions correspond to PyPI releases.
 
 ### Fixes
 * fixed a problem with patching `_io` under Python 3.12 (see [#910](../../issues/910))
+* fixed a problem with accessing the temp path if emulating Linux under Windows
+  (see [#912](../../issues/912))
 
 ## [Version 5.3.1](https://pypi.python.org/pypi/pyfakefs/5.3.0) (2023-11-15)
 Mostly a bugfix release.

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1464,6 +1464,11 @@ class FakeFilesystem:
         if path is None:
             # file.open(None) raises TypeError, so mimic that.
             raise TypeError("Expected file system path string, received None")
+        if sys.platform == "win32" and self.os != OSType.WINDOWS:
+            path = path.replace(
+                matching_string(path, os.sep),
+                matching_string(path, self.path_separator),
+            )
         if not path or not self._valid_relative_path(path):
             # file.open('') raises OSError, so mimic that, and validate that
             # all parts of a relative path exist.

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -890,6 +890,13 @@ class TestOtherFS(fake_filesystem_unittest.TestCase):
         os.chdir(folder)
         self.assertTrue(os.path.exists(str(file_path.relative_to(folder))))
 
+    @unittest.skipIf(sys.platform != "win32", "Windows-specific test")
+    def test_tempfile_access(self):
+        # regression test for #912
+        self.fs.os = OSType.LINUX
+        tmp_file = tempfile.TemporaryFile()
+        assert tmp_file
+
 
 @unittest.skipIf(sys.platform != "win32", "Windows-specific behavior")
 class TestAbsolutePathOnWindows(fake_filesystem_unittest.TestCase):


### PR DESCRIPTION
- the tempfile module will access the temp path using Windows separators under Windows, even if emulating Posix - this had to be handled
- fixes #912

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
