### PR TITLE
Fix result of os.walk with a path-like top directory

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ The released versions correspond to PyPI releases.
 * fixed a problem with patching `_io` under Python 3.12 (see [#910](../../issues/910))
 * fixed a problem with accessing the temp path if emulating Linux under Windows
   (see [#912](../../issues/912))
+* fixed result of `os.walk` with a path-like top directory
+  (see [#915](../../issues/915))
 
 ## [Version 5.3.1](https://pypi.python.org/pypi/pyfakefs/5.3.0) (2023-11-15)
 Mostly a bugfix release.

--- a/pyfakefs/fake_scandir.py
+++ b/pyfakefs/fake_scandir.py
@@ -261,7 +261,7 @@ def walk(filesystem, top, topdown=True, onerror=None, followlinks=False):
             if not topdown:
                 yield top_contents
 
-    return do_walk(to_string(top), top_most=True)
+    return do_walk(make_string_path(to_string(top)), top_most=True)
 
 
 class FakeScanDirModule:

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -1139,6 +1139,18 @@ class FakePathlibUsageInOsFunctionsTest(RealPathlibTestCase):
         with self.assertRaises(NotImplementedError):
             self.path(path).group()
 
+    def test_walk(self):
+        """Regression test for #915 - walk results shall be strings."""
+        base_dir = self.make_path("foo")
+        base_path = self.path(base_dir)
+        self.create_dir(base_path)
+        self.create_file(base_path / "1.txt")
+        self.create_file(base_path / "bar" / "2.txt")
+        result = list(step for step in self.os.walk(base_path))
+        assert len(result) == 2
+        assert result[0] == (base_dir, ["bar"], ["1.txt"])
+        assert result[1] == (self.os.path.join(base_dir, "bar"), [], ["2.txt"])
+
 
 class RealPathlibUsageInOsFunctionsTest(FakePathlibUsageInOsFunctionsTest):
     def use_real_fs(self):


### PR DESCRIPTION
- used to return a Path object for the top dir instead of a string
- fixes #915

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
