### PR TITLE
Use hookwrapper to pause patching during logreport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ The released versions correspond to PyPI releases.
   (see [#912](../../issues/912))
 * fixed result of `os.walk` with a path-like top directory
   (see [#915](../../issues/915))
+* properly fixed the problem that filesystem patching was still active in the pytest
+  logreport phase (see [#904](../../issues/904)), the previous fix was incomplete
 
 ## [Version 5.3.1](https://pypi.python.org/pypi/pyfakefs/5.3.0) (2023-11-15)
 Mostly a bugfix release.

--- a/pyfakefs/pytest_plugin.py
+++ b/pyfakefs/pytest_plugin.py
@@ -82,14 +82,12 @@ def pytest_sessionfinish(session, exitstatus):
     Patcher.clear_fs_cache()
 
 
-@pytest.hookimpl(tryfirst=True)
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_runtest_logreport(report):
     """Make sure that patching is not active during reporting."""
-    if report.when == "call" and Patcher.PATCHER is not None:
+    pause = Patcher.PATCHER is not None and report.when == "call"
+    if pause:
         Patcher.PATCHER.pause()
-
-
-def pytest_runtest_call(item):
-    """Resume paused patching before test start."""
-    if Patcher.PATCHER is not None:
+    yield
+    if pause:
         Patcher.PATCHER.resume()

--- a/pyfakefs/pytest_tests/hook_test/conftest.py
+++ b/pyfakefs/pytest_tests/hook_test/conftest.py
@@ -9,23 +9,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
+from pathlib import Path
 
 import pytest
 
 
-@pytest.fixture(scope="module", autouse=True)
-def use_fs(fs_module):
-    fs_module.create_file(os.path.join("foo", "bar"))
-    yield fs_module
+# Used for testing paused patching during reporting.
 
 
-@pytest.mark.usefixtures("fs")
-def test_fs_uses_fs_module1():
-    # check that `fs` uses the same filesystem as `fs_module`
-    assert os.path.exists(os.path.join("foo", "bar"))
-
-
-def test_fs_uses_fs_module2(fs):
-    # check that testing was not stopped by the first test
-    assert os.path.exists(os.path.join("foo", "bar"))
+@pytest.hookimpl
+def pytest_runtest_logreport(report):
+    if report.when == "call":
+        report_path = Path(__file__).parent / "report.txt"
+        with open(report_path, "w") as f:
+            f.write("Test")

--- a/pyfakefs/pytest_tests/hook_test/pytest_hook_test.py
+++ b/pyfakefs/pytest_tests/hook_test/pytest_hook_test.py
@@ -9,23 +9,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
+from pathlib import Path
 
 import pytest
 
 
-@pytest.fixture(scope="module", autouse=True)
-def use_fs(fs_module):
-    fs_module.create_file(os.path.join("foo", "bar"))
-    yield fs_module
+@pytest.fixture
+def report_path():
+    yield Path(__file__).parent / "report.txt"
 
 
-@pytest.mark.usefixtures("fs")
-def test_fs_uses_fs_module1():
-    # check that `fs` uses the same filesystem as `fs_module`
-    assert os.path.exists(os.path.join("foo", "bar"))
+def test_1(fs):
+    pass
 
 
-def test_fs_uses_fs_module2(fs):
-    # check that testing was not stopped by the first test
-    assert os.path.exists(os.path.join("foo", "bar"))
+def test_2_report_in_real_fs(report_path):
+    print("test_2_report_in_real_fs")
+    assert report_path.exists()
+    report_path.unlink()
+
+
+def test_3(fs):
+    pass
+
+
+def test_4_report_in_real_fs(report_path):
+    assert report_path.exists()
+    report_path.unlink()


### PR DESCRIPTION
- shall fix #904 more reliably

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [ ] Pre-commit CI shows no errors
- [ ] Unit tests passing
