### PR TITLE
Reload modules loaded dynamically during test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ The released versions correspond to PyPI releases.
 
 ### Fixes
 * fixes handling of unhashable modules which cannot be cached (see [#923](../../issues/923))
+* reload modules loaded by the dynamic patcher instead of removing them - sometimes they may
+  not be reloaded automatically (see [#932](../../issues/932))
 
 ## [Version 5.3.2](https://pypi.python.org/pypi/pyfakefs/5.3.2) (2023-11-30)
 Bugfix release.

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -104,7 +104,7 @@ def patchfs(
     use_known_patches: bool = True,
     patch_open_code: PatchMode = PatchMode.OFF,
     patch_default_args: bool = False,
-    use_cache: bool = True
+    use_cache: bool = True,
 ) -> Callable:
     """Convenience decorator to use patcher with additional parameters in a
     test function.
@@ -1091,12 +1091,14 @@ class DynamicPatcher(MetaPathFinder, Loader):
         reloaded_module_names = [
             module.__name__ for module in self._patcher.modules_to_reload
         ]
-        # Dereference all modules loaded during the test so they will reload on
-        # the next use, ensuring that no faked modules are referenced after the
-        # test.
+        # Reload all modules loaded during the test, ensuring that
+        # no faked modules are referenced after the test.
         for name in self._loaded_module_names:
             if name in sys.modules and name not in reloaded_module_names:
-                del sys.modules[name]
+                try:
+                    reload(sys.modules[name])
+                except Exception:
+                    del sys.modules[name]
 
     def needs_patch(self, name: str) -> bool:
         """Check if the module with the given name shall be replaced."""


### PR DESCRIPTION
- modules loaded dynamically are now reloaded instead of deleted; deleting them caused some unexpected behavior in django
- if reloading failed delete the module as last ressort 

fixes #932 

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working - I was not able to create a reliable test so far
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
