### PR TITLE
Add back argument use_dynamic_patch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ The released versions correspond to PyPI releases.
 * fixes handling of unhashable modules which cannot be cached (see [#923](../../issues/923))
 * reload modules loaded by the dynamic patcher instead of removing them - sometimes they may
   not be reloaded automatically (see [#932](../../issues/932))
+* add back argument `use_dynamic_patch` as a fallback for similar problems
+
 
 ## [Version 5.3.2](https://pypi.python.org/pypi/pyfakefs/5.3.2) (2023-11-30)
 Bugfix release.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -657,6 +657,13 @@ If you want to clear the cache just for a specific test instead, you can call
       fs.clear_cache()
       ...
 
+use_dynamic_patch
+~~~~~~~~~~~~~~~~~
+If ``True`` (the default), dynamic patching after setup is used (for example
+for modules loaded locally inside of functions).
+Can be switched off if it causes unwanted side effects, which happened at least in
+once instance while testing a django project.
+
 
 .. _convenience_methods:
 


### PR DESCRIPTION
- can be used for cases where dynamic patching causes problems
- see #932 

#### Tasks
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
