### PR TITLE
Introduce and use new argument "module_cleanup_mode"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Fixes
+* Fixes a regression due to the changed behavior of the dynamic patcher cleanup (see [#939](../../issues/939)).
+  The change is now by default only made if the `django` module is loaded, and the behavior can
+  be changed using the new argument `module_cleanup_mode`.
+
 ### Packaging
 * include `tox.ini` and a few more files into the source distribution (see [#937](../../issues/937))
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -664,6 +664,20 @@ for modules loaded locally inside of functions).
 Can be switched off if it causes unwanted side effects, which happened at least in
 once instance while testing a django project.
 
+module_cleanup_mode
+~~~~~~~~~~~~~~~~~~~
+This is a setting that works around a potential problem with the cleanup of
+dynamically loaded modules (e.g. modules loaded after the test has started),
+known to occur with `django` applications.
+The setting is subject to change or removal in future versions, provided a better
+solution for the problem is found.
+
+The setting defines how the dynamically loaded modules are cleaned up after the test
+to ensure that no patched modules can be used after the test has finished.
+The default (AUTO) currently depends on the availability of the `django` module,
+DELETE will delete all dynamically loaded modules and RELOAD will reload them.
+Under some rare conditions, changing this setting may help to avoid problems related
+to incorrect test cleanup.
 
 .. _convenience_methods:
 


### PR DESCRIPTION
- fixes a regression due to the changed behavior of the dynamic patcher cleanup The modules are now reloaded only if the django module is loaded, or the reload mode set to RELOAD.
- fixes #939 

#### Tasks
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
