### PR TITLE
Correctly handle file permissions for different classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,19 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Changes
+* The handling of file permissions under Posix is should now mostly match the behavior
+  of the real filesystem, which may change the behavior of some tests
+
 ### Fixes
 * Fixed a specific problem on reloading a pandas-related module (see [#947](../../issues/947)),
   added possibility for unload hooks for specific modules
 * Use this also to reload django views (see [#932](../../issues/932))
 * Fixed `EncodingWarning` for Python >= 3.11 (see [#957](../../issues/957))
+* Consider directory ownership while adding or removing directory entries
+  (see [#959](../../issues/959))
+* Fixed handling of directory enumeration and search permissions under Posix systems
+  (see [#960](../../issues/960))
 
 ## [Version 5.3.5](https://pypi.python.org/pypi/pyfakefs/5.3.5) (2024-01-30)
 Fixes a regression.

--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -270,8 +270,8 @@ class FakeFileOpen:
     ) -> FakeFile:
         if file_object:
             if not is_root() and (
-                (open_modes.can_read and not file_object.st_mode & PERM_READ)
-                or (open_modes.can_write and not file_object.st_mode & PERM_WRITE)
+                (open_modes.can_read and not file_object.has_permission(PERM_READ))
+                or (open_modes.can_write and not file_object.has_permission(PERM_WRITE))
             ):
                 self.filesystem.raise_os_error(errno.EACCES, file_path)
             if open_modes.can_write:

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -422,7 +422,7 @@ class FakeOsModule:
         directory = self.filesystem.resolve(path)
         # A full implementation would check permissions all the way
         # up the tree.
-        if not is_root() and not directory.st_mode | PERM_EXE:
+        if not is_root() and not directory.has_permission(PERM_EXE):
             self.filesystem.raise_os_error(errno.EACCES, directory.name)
         self.filesystem.cwd = path  # type: ignore[assignment]
 

--- a/pyfakefs/fake_scandir.py
+++ b/pyfakefs/fake_scandir.py
@@ -146,7 +146,7 @@ class ScanDirIter:
             path = make_string_path(path)
             self.abspath = self.filesystem.absnormpath(path)
             self.path = to_string(path)
-        entries = self.filesystem.confirmdir(self.abspath).entries
+        entries = self.filesystem.confirmdir(self.abspath, check_exe_perm=False).entries
         self.entry_iter = iter(entries)
 
     def __iter__(self):

--- a/pyfakefs/tests/test_utils.py
+++ b/pyfakefs/tests/test_utils.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from unittest import mock
 
 from pyfakefs import fake_filesystem, fake_open, fake_os
-from pyfakefs.helpers import is_byte_string, to_string
+from pyfakefs.helpers import is_byte_string, to_string, is_root
 
 
 class DummyTime:
@@ -226,6 +226,12 @@ class RealFsTestMixin:
                 raise unittest.SkipTest("Testing Posix specific functionality")
         else:
             self.set_windows_fs(False)
+
+    @staticmethod
+    def skip_root():
+        """Skips the test if run as root."""
+        if is_root():
+            raise unittest.SkipTest("Test only valid for non-root user")
 
     def skip_real_fs(self):
         """If called at test start, no real FS test is executed."""


### PR DESCRIPTION
- always consider the current user group while evaluating file permissions for user/group/other classes
- fixes #959 and #960

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
