### PR TITLE
Fix incorrect handling of dirfd in os.symlink

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ The released versions correspond to PyPI releases.
   (see [#960](../../issues/960))
 * fixed creation of the temp directory in the fake file system after a filesystem reset
   (see [#965](../../issues/965))
+* fixed handling of `dirfd` in `os.symlink` (see [#968](../../issues/968))
 
 ## [Version 5.3.5](https://pypi.python.org/pypi/pyfakefs/5.3.5) (2024-01-30)
 Fixes a regression.


### PR DESCRIPTION
- also removed check for supported dirfd where not used
- changed dirfd tests to run both in the fake and real OS
- fixed #968

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
