### PR TITLE
Add support for O_DIRECTORY and O_NOFOLLOW flags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,10 @@ The released versions correspond to PyPI releases.
 * fixed handling of `dirfd` in `os.symlink` (see [#968](../../issues/968))
 * add missing `follow_symlink` argument to `os.link` (see [#973](../../issues/973))
 
+### Enhancements
+* added support for `O_NOFOLLOW` and `O_DIRECTORY` flags in `os.open`
+  (see [#972](../../issues/972) and [#974](../../issues/974))
+
 ## [Version 5.3.5](https://pypi.python.org/pypi/pyfakefs/5.3.5) (2024-01-30)
 Fixes a regression.
 

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -247,6 +247,18 @@ class FakeOsModule:
             else:
                 mode = 0o777 & ~self._umask()
 
+        has_directory_flag = (
+            hasattr(os, "O_DIRECTORY") and flags & os.O_DIRECTORY == os.O_DIRECTORY
+        )
+        if has_directory_flag and not self.filesystem.isdir(path):
+            raise OSError(errno.ENOTDIR, "path is not a directory", path)
+
+        has_follow_flag = (
+            hasattr(os, "O_NOFOLLOW") and flags & os.O_NOFOLLOW == os.O_NOFOLLOW
+        )
+        if has_follow_flag and self.filesystem.islink(path):
+            raise OSError(errno.ELOOP, "path is a symlink", path)
+
         has_tmpfile_flag = (
             hasattr(os, "O_TMPFILE") and flags & os.O_TMPFILE == os.O_TMPFILE
         )


### PR DESCRIPTION
- flags are considered in os.open if present
- closes #972, closes #974

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
