### PR TITLE
Fix handling of missing attribute in os.getxattr

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ The released versions correspond to PyPI releases.
   (see [#965](../../issues/965))
 * fixed handling of `dirfd` in `os.symlink` (see [#968](../../issues/968))
 * add missing `follow_symlink` argument to `os.link` (see [#973](../../issues/973))
+* fixed handling of missing attribute in `os.getxattr` (see [#971](../../issues/971))
 
 ### Enhancements
 * added support for `O_NOFOLLOW` and `O_DIRECTORY` flags in `os.open`

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ for more information.
 pyfakefs.py was initially developed at Google by Mike Bland as a modest fake
 implementation of core Python modules.  It was introduced to all of Google
 in September 2006. Since then, it has been enhanced to extend its
-functionality and usefulness.  At last count, pyfakefs was used in over 2,000
+functionality and usefulness.  At last count, pyfakefs was used in over 20,000
 Python tests at Google.
 
 Google released pyfakefs to the public in 2011 as Google Code project

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -690,7 +690,7 @@ While ``pyfakefs`` can be used just with the standard Python file system
 functions, there are a few convenience methods in ``fake_filesystem`` that can
 help you setting up your tests. The methods can be accessed via the
 ``fake_filesystem`` instance in your tests: ``Patcher.fs``, the ``fs``
-fixture in pytest, ``TestCase.fs`` for ``unittest``, and the ``fs`` argument
+fixture in pytest, ``TestCase.fs`` for ``unittest``, and the positional argument
 for the ``patchfs`` decorator.
 
 File creation helpers
@@ -964,6 +964,10 @@ The following test works both under Windows and Linux:
       assert r"C:\foo\bar" == os.path.join("C:\\", "foo", "bar")
       assert os.path.splitdrive(r"C:\foo\bar") == ("C:", r"\foo\bar")
       assert os.path.ismount("C:")
+
+.. note:: Only behavior not relying on OS-specific functionality is emulated on another system.
+  For example, if you use the Linux-specific functionality of extended attributes (``os.getxattr`` etc.)
+  in your code, you have to test this under Linux.
 
 Set file as inaccessible under Windows
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -491,6 +491,8 @@ class FakeOsModule:
         if isinstance(attribute, bytes):
             attribute = attribute.decode(sys.getfilesystemencoding())
         file_obj = self.filesystem.resolve(path, follow_symlinks, allow_fd=True)
+        if attribute not in file_obj.xattr:
+            raise OSError(errno.ENODATA, "No data available", path)
         return file_obj.xattr.get(attribute)
 
     def listxattr(


### PR DESCRIPTION
- no tests for real OS (extended atributes not enabled in CI)
- fixes #971

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
