### PR TITLE
Fix permission handling for opening file via file descriptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ The released versions correspond to PyPI releases.
 * fixed handling of missing attribute in `os.getxattr` (see [#971](../../issues/971))
 * fixed permission problem with `shutil.rmtree` if emulating Windows under POSIX
   (see [#979](../../issues/979))
+* fixed handling of errors on opening files via file descriptor (see [#967](../../issues/967))
 
 ### Infrastructure
 * replace `undefined` by own minimal implementation to avoid importing it

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -291,7 +291,7 @@ class FakeOsModule:
                 ) or open_modes.can_write:
                     self.filesystem.raise_os_error(errno.EISDIR, path)
                 dir_wrapper = FakeDirWrapper(obj, path, self.filesystem)
-                file_des = self.filesystem._add_open_file(dir_wrapper)
+                file_des = self.filesystem.add_open_file(dir_wrapper)
                 dir_wrapper.filedes = file_des
                 return file_des
 
@@ -373,10 +373,10 @@ class FakeOsModule:
     def pipe(self) -> Tuple[int, int]:
         read_fd, write_fd = os.pipe()
         read_wrapper = FakePipeWrapper(self.filesystem, read_fd, False)
-        file_des = self.filesystem._add_open_file(read_wrapper)
+        file_des = self.filesystem.add_open_file(read_wrapper)
         read_wrapper.filedes = file_des
         write_wrapper = FakePipeWrapper(self.filesystem, write_fd, True)
-        file_des = self.filesystem._add_open_file(write_wrapper)
+        file_des = self.filesystem.add_open_file(write_wrapper)
         write_wrapper.filedes = file_des
         return read_wrapper.filedes, write_wrapper.filedes
 

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -19,6 +19,7 @@ import platform
 import stat
 import sys
 import time
+from collections import namedtuple
 from copy import copy
 from stat import S_IFLNK
 from typing import Union, Optional, Any, AnyStr, overload, cast
@@ -36,6 +37,11 @@ PERM_EXE = 0o100  # Execute permission bit.
 PERM_DEF = 0o777  # Default permission bits.
 PERM_DEF_FILE = 0o666  # Default permission bits (regular file)
 PERM_ALL = 0o7777  # All permission bits.
+
+_OpenModes = namedtuple(
+    "_OpenModes",
+    "must_exist can_read can_write truncate append must_not_exist",
+)
 
 if sys.platform == "win32":
     USER_ID = 1

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -959,6 +959,14 @@ class FakeFileOpenWithOpenerTest(FakeFileOpenTestBase):
             with self.assertRaises(OSError):
                 f.write("foo")
 
+    def test_no_opener_with_read(self):
+        file_path = self.make_path("foo")
+        self.create_file(file_path, contents="test")
+        with self.open(file_path) as f:
+            assert f.read() == "test"
+            with self.assertRaises(OSError):
+                f.write("foo")
+
     def test_use_opener_with_read_plus(self):
         file_path = self.make_path("foo")
         self.create_file(file_path, contents="test")


### PR DESCRIPTION
- fixes #967

This fixes at least some of the issues with permission handling if opening files via the file descriptor.
I'm sure there are more problems, as the description of the behavior in the Python documentation is not sufficient and you have to fall back to OS-specific documentation. Also, there are differences in the behavior between CPython and PyPy.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
