### PR TITLE
Fix behavior of fake os.makedirs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ The released versions correspond to PyPI releases.
   (see [#979](../../issues/979))
 * fixed handling of errors on opening files via file descriptor (see [#967](../../issues/967))
 * fixed handling of `umask` - it is now applied by default
+* fixed behavior of `os.makedirs` (see [#987](../../issues/987))
 
 ### Infrastructure
 * replace `undefined` by own minimal implementation to avoid importing it

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -1893,6 +1893,14 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         self.assert_raises_os_error(errno.ENOENT, self.os.makedirs, "", exist_ok=False)
         self.assert_raises_os_error(errno.ENOENT, self.os.makedirs, "", exist_ok=True)
 
+    def test_makedirs_with_relative_paths(self):
+        # regression test for #987
+        path = self.make_path("base", "foo", "..", "bar")
+        self.os.makedirs(path)
+        self.assertTrue(self.os.path.isdir(self.make_path("base", "bar")))
+        self.assertTrue(self.os.path.isdir(self.make_path("base", "foo")))
+        self.assertFalse(self.os.path.isdir(self.make_path("base", "foo", "bar")))
+
     # test fsync and fdatasync
     def test_fsync_raises_on_non_int(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
- use a similar implementation as the real fs
- fixes #987

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
