### PR TITLE
Remove unneeded check leading to a regression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # pyfakefs Release Notes
 The released versions correspond to PyPI releases.
 
+## Unreleased
+
+### Fixes
+* fixed a regression from version 5.4.0 that incorrectly handled files opened twice via file descriptor
+  (see [#997](../../issues/997))
+
 ## [Version 5.4.0](https://pypi.python.org/pypi/pyfakefs/5.4.0) (2024-04-07)
 Improves permission handling.
 

--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -144,12 +144,6 @@ class FakeFileOpen:
 
         newline, open_modes = self._handle_file_mode(mode, newline, open_modes)
         opened_as_fd = isinstance(file_, int)
-        if opened_as_fd and not helpers.IS_PYPY:
-            fd: int = cast(int, file_)
-            # cannot open the same file descriptor twice, except in PyPy
-            for f in self.filesystem.get_open_files(fd):
-                if isinstance(f, FakeFileWrapper) and f.opened_as_fd:
-                    raise OSError(errno.EBADF, "Bad file descriptor")
 
         # the pathlib opener is defined in a Path instance that may not be
         # patched under some circumstances; as it just calls standard open(),


### PR DESCRIPTION
- the check had been incorrecty introduced to fix an issue ultimately related to reference counting/garbage collection
- the fix was incorrect, and that case can probably be ignored, as the code laeding to it makes no sense
- fixes #997

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
