### PR TITLE
Align Python version testing in tox with CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,pypy3
+envlist =
+    py{37,38,39,310,311,312}
+    pypy{37,39,310}
 
 [testenv]
 deps =


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are still in progress.
-->

#### Describe the changes

This change aligns the Python versions that are tested by tox with those tested by CI. In particular:

* py312 is added
* pypy versions are explicitly called out (excluding pypy38, which appears to segfault locally and doesn't seem to be tested in CI)

I attempted to run the tox environments in parallel (using `tox p` or `tox run-parallel`) and discovered that files and symlinks are written to the local directory, causing failures in the parallel test suites due to filesystem access conflicts. This PR doesn't address that issue, which likely requires establishing temp directories at test startup.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Entry to release notes added
- [ ] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
