### PR TITLE
Fix pure windows path behavior

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ The released versions correspond to PyPI releases.
 * The usage of the `pathlib2` and `scandir` modules in pyfakefs is now deprecated.
   They will now cause deprecation warnings if still used. Support for patching
   these modules will be removed in pyfakefs 6.0.
+* `PureWindowsPath` and `PurePosixPath` now use filesystem-independent path separators,
+  and their path-parsing behaviors are now consistent regardless of runtime platform
+  and/or faked filesystem customization (see [#1006](../../issues/1006)).
 
 ## [Version 5.4.1](https://pypi.python.org/pypi/pyfakefs/5.4.0) (2024-04-11)
 Fixes a regression.

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -392,6 +392,13 @@ if sys.version_info < (3, 12):
         )
         pathmod = ntpath
 
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # Because this class is used with pure Windows paths,
+            # the separators must be filesystem-independent.
+            self.sep = "\\"
+            self.altsep = "/"
+
         def is_reserved(self, parts):
             """Return True if the path is considered reserved under Windows."""
 

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -60,10 +60,15 @@ def init_module(filesystem):
     else:
         # in Python 3.12, the flavour is no longer an own class,
         # but points to the os-specific path module (posixpath/ntpath)
-        fake_os = FakeOsModule(filesystem)
-        fake_path = fake_os.path
-        FakePathlibModule.PureWindowsPath._flavour = fake_path
-        FakePathlibModule.PurePosixPath._flavour = fake_path
+        fake_posix_os = FakeOsModule(filesystem)
+        fake_posix_path = fake_posix_os.path
+        FakePathlibModule.PurePosixPath._flavour = fake_posix_path
+        # The Windows path separators must be customized.
+        fake_nt_os = FakeOsModule(filesystem)
+        fake_nt_path = fake_nt_os.path
+        fake_nt_path.sep = "\\"
+        fake_nt_path.altsep = "/"
+        FakePathlibModule.PureWindowsPath._flavour = fake_nt_path
 
 
 def _wrap_strfunc(strfunc):

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -1286,5 +1286,22 @@ class FakeFilesystemChmodTest(fake_filesystem_unittest.TestCase):
             path.is_file()
 
 
+class FakePathlibModulePurePathTest(unittest.TestCase):
+    def test_windows_pure_path_parsing(self):
+        """Verify faked pure Windows paths use filesystem-independent separators."""
+
+        path = r"C:\Windows\cmd.exe"
+        self.assertEqual(
+            fake_pathlib.FakePathlibModule.PureWindowsPath(path).stem,
+            pathlib.PureWindowsPath(path).stem,
+        )
+
+        path = r"C:/Windows/cmd.exe"
+        self.assertEqual(
+            fake_pathlib.FakePathlibModule.PureWindowsPath(path).stem,
+            pathlib.PureWindowsPath(path).stem,
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -1302,6 +1302,15 @@ class FakePathlibModulePurePathTest(unittest.TestCase):
             pathlib.PureWindowsPath(path).stem,
         )
 
+    def test_posix_pure_path_parsing(self):
+        """Verify faked pure POSIX paths use filesystem-independent separators."""
+
+        path = r"/bin/bash"
+        self.assertEqual(
+            fake_pathlib.FakePathlibModule.PurePosixPath(path).stem,
+            pathlib.PurePosixPath(path).stem,
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
Please prefix your PR title with [WIP] for PRs that are still in progress.
-->

#### Describe the changes
This PR fixes path separators for Windows paths.

> [!NOTE]
>
> A single regression test for #558 fails as a result of this change, and only on Python 3.12. I am uneasy touching this test because I harbor concerns that this test is enforcing behavior that might not be worthwhile to support.
>
> Please review this work, together with this test, and let me know how to proceed. My gut is to remove the failing regression test but I didn't include that here.

Fixes #1006 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [ ] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
