### PR TITLE
Handle skipped pathlib.Path.open calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ The released versions correspond to PyPI releases.
   and their path-parsing behaviors are now consistent regardless of runtime platform
   and/or faked filesystem customization (see [#1006](../../issues/1006)).
 
+### Fixes
+* correctly use real open calls in pathlib for skipped modules (see [#1012](../../issues/1012))
+
 ## [Version 5.4.1](https://pypi.python.org/pypi/pyfakefs/5.4.0) (2024-04-11)
 Fixes a regression.
 

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -26,7 +26,8 @@ import unittest
 from pyfakefs import fake_filesystem, helpers
 from pyfakefs.helpers import is_root, IS_PYPY, get_locale_encoding
 from pyfakefs.fake_io import FakeIoModule
-from pyfakefs.fake_filesystem_unittest import PatchMode
+from pyfakefs.fake_filesystem_unittest import PatchMode, Patcher
+from pyfakefs.tests.skip_open import read_open
 from pyfakefs.tests.test_utils import RealFsTestCase
 
 
@@ -2102,6 +2103,13 @@ class ResolvePathTest(FakeFileOpenTestBase):
 class RealResolvePathTest(ResolvePathTest):
     def use_real_fs(self):
         return True
+
+
+class SkipOpenTest(unittest.TestCase):
+    def test_open_in_skipped_module(self):
+        with Patcher(additional_skip_names=["skip_open"]):
+            contents = read_open("skip_open.py")
+            self.assertTrue(contents.startswith("# Licensed under the Apache License"))
 
 
 if __name__ == "__main__":

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -31,7 +31,9 @@ from unittest.mock import patch
 
 from pyfakefs import fake_pathlib, fake_filesystem, fake_filesystem_unittest, fake_os
 from pyfakefs.fake_filesystem import OSType
+from pyfakefs.fake_filesystem_unittest import Patcher
 from pyfakefs.helpers import IS_PYPY, is_root
+from pyfakefs.tests.skip_open import read_pathlib
 from pyfakefs.tests.test_utils import RealFsTestMixin
 
 is_windows = sys.platform == "win32"
@@ -1310,6 +1312,14 @@ class FakePathlibModulePurePathTest(unittest.TestCase):
             fake_pathlib.FakePathlibModule.PurePosixPath(path).stem,
             pathlib.PurePosixPath(path).stem,
         )
+
+
+class SkipOpenTest(unittest.TestCase):
+    def test_open_pathlib_in_skipped_module(self):
+        # regression test for #1012
+        with Patcher(additional_skip_names=["skip_open"]):
+            contents = read_pathlib("skip_open.py")
+            self.assertTrue(contents.startswith("# Licensed under the Apache License"))
 
 
 if __name__ == "__main__":

--- a/pyfakefs/tests/skip_open.py
+++ b/pyfakefs/tests/skip_open.py
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Provides functions for testing additional_skip_names functionality.
+"""
+
+import os
+from pathlib import Path
+
+
+def read_pathlib(file_name):
+    return (Path(__file__).parent / file_name).open("r").read()
+
+
+def read_open(file_name):
+    with open(os.path.join(os.path.dirname(__file__), file_name)) as f:
+        return f.read()


### PR DESCRIPTION
- if a module is skipped using additional_skip_names, Path.open is now handled the same way as io.open to use real fs calls
- fixes #1012

I'm not too happy about the skip module handling, may revisit this later.

#### Describe the changes
The related issue or a description of the bug or feature that this PR addresses.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
