### PR TITLE
Handle other pathlib.Path.open calls in read_text, read_bytes, write_text and write_bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@ The released versions correspond to PyPI releases.
 * remove support for patching legacy modules `scandir` and `pathlib2`
 * remove support for Python 3.7
 
+## Unreleased
+
+### Fixes
+
+* Use real open calls for remaining `pathlib` functions so that it works nice with skippedmodules (see #1012)
+
 ## [Version 5.5.0](https://pypi.python.org/pypi/pyfakefs/5.5.0) (2024-05-12)
 Deprecates the usage of `pathlib2` and `scandir`.
 

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -1258,6 +1258,10 @@ class StandardStreamWrapper:
     def read(self, n: int = -1) -> bytes:
         return cast(bytes, self._stream_object.read())
 
+    def write(self, contents: bytes) -> int:
+        self._stream_object.write(cast(str, contents))
+        return len(contents)
+
     def close(self) -> None:
         """We do not support closing standard streams."""
 
@@ -1266,6 +1270,19 @@ class StandardStreamWrapper:
 
     def is_stream(self) -> bool:
         return True
+
+    def __enter__(self) -> "StandardStreamWrapper":
+        """To support usage of this standard stream with the 'with' statement."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """To support usage of this standard stream with the 'with' statement."""
+        self.close()
 
 
 class FakeDirWrapper:
@@ -1301,6 +1318,28 @@ class FakeDirWrapper:
         """Close the directory."""
         assert fd is not None
         self._filesystem.close_open_file(fd)
+
+    def read(self, numBytes: int = -1) -> bytes:
+        """Read from the directory."""
+        return self.file_object.read(numBytes)
+
+    def write(self, contents: bytes) -> int:
+        """Write to the directory."""
+        self.file_object.write(contents)
+        return len(contents)
+
+    def __enter__(self) -> "FakeDirWrapper":
+        """To support usage of this fake directory with the 'with' statement."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        """To support usage of this fake directory with the 'with' statement."""
+        self.close()
 
 
 class FakePipeWrapper:

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -45,7 +45,7 @@ from urllib.parse import quote_from_bytes as urlquote_from_bytes
 
 from pyfakefs import fake_scandir
 from pyfakefs.fake_filesystem import FakeFilesystem
-from pyfakefs.fake_open import FakeFileOpen, fake_open
+from pyfakefs.fake_open import fake_open
 from pyfakefs.fake_os import FakeOsModule, use_original_os
 from pyfakefs.helpers import IS_PYPY
 
@@ -650,17 +650,25 @@ class FakePath(pathlib.Path):
             OSError: if the target object is a directory, the path is
                 invalid or permission is denied.
         """
-        with FakeFileOpen(self.filesystem)(
-            self._path(), mode="rb"
-        ) as f:  # pytype: disable=attribute-error
+        with fake_open(
+            self.filesystem,
+            self.skip_names,
+            self._path(),
+            mode="rb",
+        ) as f:
             return f.read()
 
     def read_text(self, encoding=None, errors=None):
         """
         Open the fake file in text mode, read it, and close the file.
         """
-        with FakeFileOpen(self.filesystem)(  # pytype: disable=attribute-error
-            self._path(), mode="r", encoding=encoding, errors=errors
+        with fake_open(
+            self.filesystem,
+            self.skip_names,
+            self._path(),
+            mode="r",
+            encoding=encoding,
+            errors=errors,
         ) as f:
             return f.read()
 
@@ -674,9 +682,12 @@ class FakePath(pathlib.Path):
         """
         # type-check for the buffer interface before truncating the file
         view = memoryview(data)
-        with FakeFileOpen(self.filesystem)(
-            self._path(), mode="wb"
-        ) as f:  # pytype: disable=attribute-error
+        with fake_open(
+            self.filesystem,
+            self.skip_names,
+            self._path(),
+            mode="wb",
+        ) as f:
             return f.write(view)
 
     def write_text(self, data, encoding=None, errors=None, newline=None):
@@ -701,7 +712,9 @@ class FakePath(pathlib.Path):
             raise TypeError(
                 "write_text() got an unexpected " "keyword argument 'newline'"
             )
-        with FakeFileOpen(self.filesystem)(  # pytype: disable=attribute-error
+        with fake_open(
+            self.filesystem,
+            self.skip_names,
             self._path(),
             mode="w",
             encoding=encoding,

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -27,7 +27,7 @@ from pyfakefs import fake_filesystem, helpers
 from pyfakefs.helpers import is_root, IS_PYPY, get_locale_encoding
 from pyfakefs.fake_io import FakeIoModule
 from pyfakefs.fake_filesystem_unittest import PatchMode, Patcher
-from pyfakefs.tests.skip_open import read_open
+from pyfakefs.tests.skipped_pathlib import read_open
 from pyfakefs.tests.test_utils import RealFsTestCase
 
 
@@ -2107,8 +2107,8 @@ class RealResolvePathTest(ResolvePathTest):
 
 class SkipOpenTest(unittest.TestCase):
     def test_open_in_skipped_module(self):
-        with Patcher(additional_skip_names=["skip_open"]):
-            contents = read_open("skip_open.py")
+        with Patcher(additional_skip_names=["skipped_pathlib"]):
+            contents = read_open("skipped_pathlib.py")
             self.assertTrue(contents.startswith("# Licensed under the Apache License"))
 
 

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -31,9 +31,12 @@ from unittest.mock import patch
 
 from pyfakefs import fake_pathlib, fake_filesystem, fake_filesystem_unittest, fake_os
 from pyfakefs.fake_filesystem import OSType
-from pyfakefs.fake_filesystem_unittest import Patcher
 from pyfakefs.helpers import IS_PYPY, is_root
-from pyfakefs.tests.skip_open import read_pathlib
+from pyfakefs.tests.skipped_pathlib import (
+    read_bytes_pathlib,
+    read_pathlib,
+    read_text_pathlib,
+)
 from pyfakefs.tests.test_utils import RealFsTestMixin
 
 is_windows = sys.platform == "win32"
@@ -1314,12 +1317,24 @@ class FakePathlibModulePurePathTest(unittest.TestCase):
         )
 
 
-class SkipOpenTest(unittest.TestCase):
-    def test_open_pathlib_in_skipped_module(self):
+class SkipPathlibTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs(additional_skip_names=["skipped_pathlib"])
+
+    def test_open_in_skipped_module(self):
         # regression test for #1012
-        with Patcher(additional_skip_names=["skip_open"]):
-            contents = read_pathlib("skip_open.py")
-            self.assertTrue(contents.startswith("# Licensed under the Apache License"))
+        contents = read_pathlib("skipped_pathlib.py")
+        self.assertTrue(contents.startswith("# Licensed under the Apache License"))
+
+    def test_read_text_in_skipped_module(self):
+        # regression test for #1012
+        contents = read_text_pathlib("skipped_pathlib.py")
+        self.assertTrue(contents.startswith("# Licensed under the Apache License"))
+
+    def test_read_bytes_in_skipped_module(self):
+        # regression test for #1012
+        contents = read_bytes_pathlib("skipped_pathlib.py")
+        self.assertTrue(contents.startswith(b"# Licensed under the Apache License"))
 
 
 if __name__ == "__main__":

--- a/pyfakefs/tests/skipped_pathlib.py
+++ b/pyfakefs/tests/skipped_pathlib.py
@@ -21,6 +21,14 @@ def read_pathlib(file_name):
     return (Path(__file__).parent / file_name).open("r").read()
 
 
+def read_text_pathlib(file_name):
+    return (Path(__file__).parent / file_name).read_text()
+
+
+def read_bytes_pathlib(file_name):
+    return (Path(__file__).parent / file_name).read_bytes()
+
+
 def read_open(file_name):
     with open(os.path.join(os.path.dirname(__file__), file_name)) as f:
         return f.read()


### PR DESCRIPTION
#### Describe the changes
The related issue or a description of the bug or feature that this PR addresses.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
