### PR TITLE
[WIP] Make fake filesystem, fake `os` and fake `os.path` respect `additional_skip_names`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
           - "--py37-plus"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.5.5"
+    rev: "v0.5.6"
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -46,7 +46,7 @@ repos:
         language: python
         files: \.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.11.1
     hooks:
       - id: mypy
         exclude: (docs|pyfakefs/tests)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
           - "--py37-plus"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.5.6"
+    rev: "v0.5.7"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: "https://github.com/asottile/pyupgrade"
-    rev: "v3.16.0"
+    rev: "v3.17.0"
     hooks:
       - id: "pyupgrade"
         name: "Enforce Python 3.7+ idioms"
@@ -11,7 +11,7 @@ repos:
           - "--py37-plus"
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.5.4"
+    rev: "v0.5.5"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,12 @@ The released versions correspond to PyPI releases.
 * the default for `FakeFilesystem.shuffle_listdir_results` will change to `True` to reflect
   the real filesystem behavior
 
+## Unreleased
+
+### Enhancements
+
+- refactor the implementation of `additional_skip_names` parameter to make it work with more modules (see [#1023](../../issues/1023))
+
 ## [Version 5.6.0](https://pypi.python.org/pypi/pyfakefs/5.6.0) (2024-07-12)
 Adds preliminary Python 3.13 support.
 

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -603,8 +603,8 @@ class FakeDirectory(FakeFile):
                     st = traceback.extract_stack(limit=6)
                     if sys.version_info < (3, 10):
                         if (
-                            st[1].name == "TemporaryFile"
-                            and st[1].line == "_os.unlink(name)"
+                            st[0].name == "TemporaryFile"
+                            and st[0].line == "_os.unlink(name)"
                         ):
                             raise_error = False
                     else:

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -570,7 +570,7 @@ class Patcher:
             set_uid(1)
             set_gid(1)
 
-        self._skip_names = self.SKIPNAMES.copy()
+        self.skip_names = self.SKIPNAMES.copy()
         # save the original open function for use in pytest plugin
         self.original_open = open
         self.patch_open_code = patch_open_code
@@ -582,7 +582,7 @@ class Patcher:
                 cast(ModuleType, m).__name__ if inspect.ismodule(m) else cast(str, m)
                 for m in additional_skip_names
             ]
-            self._skip_names.update(skip_names)
+            self.skip_names.update(skip_names)
 
         self._fake_module_classes: Dict[str, Any] = {}
         self._unfaked_module_classes: Dict[str, Any] = {}
@@ -628,8 +628,8 @@ class Patcher:
             if patched_module_names != self.PATCHED_MODULE_NAMES:
                 self.__class__.PATCHED_MODULE_NAMES = patched_module_names
                 clear_cache = True
-            if self._skip_names != self.ADDITIONAL_SKIP_NAMES:
-                self.__class__.ADDITIONAL_SKIP_NAMES = self._skip_names
+            if self.skip_names != self.ADDITIONAL_SKIP_NAMES:
+                self.__class__.ADDITIONAL_SKIP_NAMES = self.skip_names
                 clear_cache = True
             if patch_default_args != self.PATCH_DEFAULT_ARGS:
                 self.__class__.PATCH_DEFAULT_ARGS = patch_default_args
@@ -875,7 +875,7 @@ class Patcher:
                         pass
                 continue
             skipped = module in self.SKIPMODULES or any(
-                [sn.startswith(module.__name__) for sn in self._skip_names]
+                [sn.startswith(module.__name__) for sn in self.skip_names]
             )
             module_items = module.__dict__.copy().items()
 
@@ -922,7 +922,7 @@ class Patcher:
         for name in self._fake_module_classes:
             self.fake_modules[name] = self._fake_module_classes[name](self.fs)
             if hasattr(self.fake_modules[name], "skip_names"):
-                self.fake_modules[name].skip_names = self._skip_names
+                self.fake_modules[name].skip_names = self.skip_names
         self.fake_modules[PATH_MODULE] = self.fake_modules["os"].path
         for name in self._unfaked_module_classes:
             self.unfaked_modules[name] = self._unfaked_module_classes[name]()

--- a/pyfakefs/fake_io.py
+++ b/pyfakefs/fake_io.py
@@ -182,11 +182,14 @@ if sys.platform != "win32":
 
         def __getattribute__(self, name):
             """Forwards any unfaked calls to the standard fcntl module."""
-            filesystem = object.__getattribute__(self, "filesystem")
+            fs: FakeFilesystem = object.__getattribute__(self, "filesystem")
             fnctl_module = object.__getattribute__(self, "_fcntl_module")
-            if filesystem.patcher:
-                skip_names = filesystem.patcher._skip_names
-                if is_called_from_skipped_module(skip_names=skip_names):
+            if fs.patcher:
+                skip_names = fs.patcher.skip_names
+                if is_called_from_skipped_module(
+                    skip_names=skip_names,
+                    case_sensitive=fs.is_case_sensitive,
+                ):
                     # remove the `self` argument for FakeOsModule methods
                     return getattr(fnctl_module, name)
 

--- a/pyfakefs/fake_io.py
+++ b/pyfakefs/fake_io.py
@@ -185,9 +185,8 @@ if sys.platform != "win32":
             fs: FakeFilesystem = object.__getattribute__(self, "filesystem")
             fnctl_module = object.__getattribute__(self, "_fcntl_module")
             if fs.patcher:
-                skip_names = fs.patcher.skip_names
                 if is_called_from_skipped_module(
-                    skip_names=skip_names,
+                    skip_names=fs.patcher.skip_names,
                     case_sensitive=fs.is_case_sensitive,
                 ):
                     # remove the `self` argument for FakeOsModule methods

--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -86,7 +86,10 @@ def fake_open(
     """Redirect the call to FakeFileOpen.
     See FakeFileOpen.call() for description.
     """
-    if is_called_from_skipped_module(skip_names=skip_names):
+    if is_called_from_skipped_module(
+        skip_names=skip_names,
+        case_sensitive=filesystem.is_case_sensitive,
+    ):
         return io_open(  # pytype: disable=wrong-arg-count
             file,
             mode,

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -1421,9 +1421,13 @@ def handle_original_call(f: Callable) -> Callable:
 
         if not should_use_original and args:
             self = args[0]
+            fs: FakeFilesystem = self.filesystem
             if self.filesystem.patcher:
-                skip_names = self.filesystem.patcher._skip_names
-                if is_called_from_skipped_module(skip_names=skip_names):
+                skip_names = fs.patcher.skip_names
+                if is_called_from_skipped_module(
+                    skip_names=skip_names,
+                    case_sensitive=fs.is_case_sensitive,
+                ):
                     should_use_original = True
 
         if should_use_original:

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -54,6 +54,7 @@ from pyfakefs.fake_path import FakePathModule
 from pyfakefs.fake_scandir import scandir, walk, ScanDirIter
 from pyfakefs.helpers import (
     FakeStatResult,
+    is_called_from_skipped_module,
     is_int_type,
     is_byte_string,
     make_string_path,
@@ -1409,27 +1410,36 @@ class FakeOsModule:
         return getattr(self.os_module, name)
 
 
-if sys.version_info > (3, 10):
+def handle_original_call(f: Callable) -> Callable:
+    """Decorator used for real pathlib Path methods to ensure that
+    real os functions instead of faked ones are used.
+    Applied to all non-private methods of `FakeOsModule`."""
 
-    def handle_original_call(f: Callable) -> Callable:
-        """Decorator used for real pathlib Path methods to ensure that
-        real os functions instead of faked ones are used.
-        Applied to all non-private methods of `FakeOsModule`."""
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        should_use_original = FakeOsModule.use_original
 
-        @functools.wraps(f)
-        def wrapped(*args, **kwargs):
-            if FakeOsModule.use_original:
-                # remove the `self` argument for FakeOsModule methods
-                if args and isinstance(args[0], FakeOsModule):
-                    args = args[1:]
-                return getattr(os, f.__name__)(*args, **kwargs)
-            return f(*args, **kwargs)
+        if not should_use_original and args:
+            self = args[0]
+            if self.filesystem.patcher:
+                skip_names = self.filesystem.patcher._skip_names
+                if is_called_from_skipped_module(skip_names=skip_names):
+                    should_use_original = True
 
-        return wrapped
+        if should_use_original:
+            # remove the `self` argument for FakeOsModule methods
+            if args and isinstance(args[0], FakeOsModule):
+                args = args[1:]
+            return getattr(os, f.__name__)(*args, **kwargs)
 
-    for name, fn in inspect.getmembers(FakeOsModule, inspect.isfunction):
-        if not fn.__name__.startswith("_"):
-            setattr(FakeOsModule, name, handle_original_call(fn))
+        return f(*args, **kwargs)
+
+    return wrapped
+
+
+for name, fn in inspect.getmembers(FakeOsModule, inspect.isfunction):
+    if not fn.__name__.startswith("_"):
+        setattr(FakeOsModule, name, handle_original_call(fn))
 
 
 @contextmanager

--- a/pyfakefs/fake_path.py
+++ b/pyfakefs/fake_path.py
@@ -570,8 +570,11 @@ def handle_original_call(f: Callable) -> Callable:
             self = args[0]
             should_use_original = self.os.use_original
             if not should_use_original and self.filesystem.patcher:
-                skip_names = self.filesystem.patcher._skip_names
-                if is_called_from_skipped_module(skip_names=skip_names):
+                skip_names = self.filesystem.patcher.skip_names
+                if is_called_from_skipped_module(
+                    skip_names=skip_names,
+                    case_sensitive=self.filesystem.is_case_sensitive,
+                ):
                     should_use_original = True
 
             if should_use_original:

--- a/pyfakefs/fake_path.py
+++ b/pyfakefs/fake_path.py
@@ -15,6 +15,8 @@
 """Faked ``os.path`` module replacement. See ``fake_filesystem`` for usage."""
 
 import errno
+import functools
+import inspect
 import os
 import sys
 from stat import (
@@ -23,6 +25,7 @@ from stat import (
 )
 from types import ModuleType
 from typing import (
+    Callable,
     List,
     Optional,
     Union,
@@ -36,6 +39,7 @@ from typing import (
 )
 
 from pyfakefs.helpers import (
+    is_called_from_skipped_module,
     make_string_path,
     to_string,
     matching_string,
@@ -553,3 +557,34 @@ if sys.platform == "win32":
         def __getattr__(self, name: str) -> Any:
             """Forwards any non-faked calls to the real nt module."""
             return getattr(self.nt_module, name)
+
+
+def handle_original_call(f: Callable) -> Callable:
+    """Decorator used for real pathlib Path methods to ensure that
+    real os functions instead of faked ones are used.
+    Applied to all non-private methods of `FakePathModule`."""
+
+    @functools.wraps(f)
+    def wrapped(*args, **kwargs):
+        if args:
+            self = args[0]
+            should_use_original = self.os.use_original
+            if not should_use_original and self.filesystem.patcher:
+                skip_names = self.filesystem.patcher._skip_names
+                if is_called_from_skipped_module(skip_names=skip_names):
+                    should_use_original = True
+
+            if should_use_original:
+                # remove the `self` argument for FakePathModule methods
+                if args and isinstance(args[0], FakePathModule):
+                    args = args[1:]
+                return getattr(os.path, f.__name__)(*args, **kwargs)
+
+        return f(*args, **kwargs)
+
+    return wrapped
+
+
+for name, fn in inspect.getmembers(FakePathModule, inspect.isfunction):
+    if not fn.__name__.startswith("_"):
+        setattr(FakePathModule, name, handle_original_call(fn))

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -93,62 +93,47 @@ def init_module(filesystem):
         setattr(FakePathlibModule.PureWindowsPath, parser_name, fake_pure_nt_os.path)
 
 
-def _wrap_strfunc(strfunc):
-    @functools.wraps(strfunc)
+def _wrap_strfunc(fake_fct, original_fct):
+    @functools.wraps(fake_fct)
     def _wrapped(pathobj, *args, **kwargs):
-        should_use_original = False
-        if pathobj.filesystem.patcher:
-            skip_names = pathobj.filesystem.patcher._skip_names
-            if is_called_from_skipped_module(skip_names=skip_names):
-                should_use_original = True
-
-        if should_use_original:
-            return getattr(pathobj._original_accessor, strfunc.__name__)(
-                str(pathobj),
-                *args,
-                **kwargs,
-            )
-        return strfunc(pathobj.filesystem, str(pathobj), *args, **kwargs)
+        fs: FakeFilesystem = pathobj.filesystem
+        if fs.patcher:
+            if is_called_from_skipped_module(
+                skip_names=fs.patcher.skip_names,
+                case_sensitive=fs.is_case_sensitive,
+            ):
+                return original_fct(str(pathobj), *args, **kwargs)
+        return fake_fct(fs, str(pathobj), *args, **kwargs)
 
     return staticmethod(_wrapped)
 
 
-def _wrap_binary_strfunc(strfunc):
-    @functools.wraps(strfunc)
+def _wrap_binary_strfunc(fake_fct, original_fct):
+    @functools.wraps(fake_fct)
     def _wrapped(pathobj1, pathobj2, *args):
-        should_use_original = False
-        if pathobj1.filesystem.patcher:
-            skip_names = pathobj1.filesystem.patcher._skip_names
-            if is_called_from_skipped_module(skip_names=skip_names):
-                should_use_original = True
-
-        if should_use_original:
-            return getattr(pathobj1._original_accessor, strfunc.__name__)(
-                str(pathobj1),
-                str(pathobj2),
-                *args,
-            )
-        return strfunc(pathobj1.filesystem, str(pathobj1), str(pathobj2), *args)
+        fs: FakeFilesystem = pathobj1.filesystem
+        if fs.patcher:
+            if is_called_from_skipped_module(
+                skip_names=fs.patcher.skip_names,
+                case_sensitive=fs.is_case_sensitive,
+            ):
+                return original_fct(str(pathobj1), str(pathobj2), *args)
+        return fake_fct(fs, str(pathobj1), str(pathobj2), *args)
 
     return staticmethod(_wrapped)
 
 
-def _wrap_binary_strfunc_reverse(strfunc):
-    @functools.wraps(strfunc)
+def _wrap_binary_strfunc_reverse(fake_fct, original_fct):
+    @functools.wraps(fake_fct)
     def _wrapped(pathobj1, pathobj2, *args):
-        should_use_original = False
-        if pathobj2.filesystem.patcher:
-            skip_names = pathobj2.filesystem.patcher._skip_names
-            if is_called_from_skipped_module(skip_names=skip_names):
-                should_use_original = True
-
-        if should_use_original:
-            return getattr(pathobj2._original_accessor, strfunc.__name__)(
-                str(pathobj2),
-                str(pathobj1),
-                *args,
-            )
-        return strfunc(pathobj2.filesystem, str(pathobj2), str(pathobj1), *args)
+        fs: FakeFilesystem = pathobj2.filesystem
+        if fs.patcher:
+            if is_called_from_skipped_module(
+                skip_names=fs.patcher.skip_names,
+                case_sensitive=fs.is_case_sensitive,
+            ):
+                return original_fct(str(pathobj2), str(pathobj1), *args)
+        return fake_fct(fs, str(pathobj2), str(pathobj1), *args)
 
     return staticmethod(_wrapped)
 
@@ -164,20 +149,21 @@ class _FakeAccessor(accessor):  # type: ignore[valid-type, misc]
     methods.
     """
 
-    stat = _wrap_strfunc(FakeFilesystem.stat)
+    stat = _wrap_strfunc(FakeFilesystem.stat, os.stat)
 
     lstat = _wrap_strfunc(
-        lambda fs, path: FakeFilesystem.stat(fs, path, follow_symlinks=False)
+        lambda fs, path: FakeFilesystem.stat(fs, path, follow_symlinks=False), os.lstat
     )
 
-    listdir = _wrap_strfunc(FakeFilesystem.listdir)
-    scandir = _wrap_strfunc(fake_scandir.scandir)
+    listdir = _wrap_strfunc(FakeFilesystem.listdir, os.listdir)
+    scandir = _wrap_strfunc(fake_scandir.scandir, os.scandir)
 
     if hasattr(os, "lchmod"):
         lchmod = _wrap_strfunc(
             lambda fs, path, mode: FakeFilesystem.chmod(
                 fs, path, mode, follow_symlinks=False
-            )
+            ),
+            os.lchmod,
         )
     else:
 
@@ -200,47 +186,51 @@ class _FakeAccessor(accessor):  # type: ignore[valid-type, misc]
                 )
         return pathobj.filesystem.chmod(str(pathobj), *args, **kwargs)
 
-    mkdir = _wrap_strfunc(FakeFilesystem.makedir)
+    mkdir = _wrap_strfunc(FakeFilesystem.makedir, os.mkdir)
 
-    unlink = _wrap_strfunc(FakeFilesystem.remove)
+    unlink = _wrap_strfunc(FakeFilesystem.remove, os.unlink)
 
-    rmdir = _wrap_strfunc(FakeFilesystem.rmdir)
+    rmdir = _wrap_strfunc(FakeFilesystem.rmdir, os.rmdir)
 
-    rename = _wrap_binary_strfunc(FakeFilesystem.rename)
+    rename = _wrap_binary_strfunc(FakeFilesystem.rename, os.rename)
 
     replace = _wrap_binary_strfunc(
         lambda fs, old_path, new_path: FakeFilesystem.rename(
             fs, old_path, new_path, force_replace=True
-        )
+        ),
+        os.replace,
     )
 
     symlink = _wrap_binary_strfunc_reverse(
         lambda fs, fpath, target, target_is_dir: FakeFilesystem.create_symlink(
             fs, fpath, target, create_missing_dirs=False
-        )
+        ),
+        os.symlink,
     )
 
     if (3, 8) <= sys.version_info:
         link_to = _wrap_binary_strfunc(
             lambda fs, file_path, link_target: FakeFilesystem.link(
                 fs, file_path, link_target
-            )
+            ),
+            os.link,
         )
 
     if sys.version_info >= (3, 10):
         link = _wrap_binary_strfunc(
             lambda fs, file_path, link_target: FakeFilesystem.link(
                 fs, file_path, link_target
-            )
+            ),
+            os.link,
         )
 
         # this will use the fake filesystem because os is patched
         def getcwd(self):
             return os.getcwd()
 
-    readlink = _wrap_strfunc(FakeFilesystem.readlink)
+    readlink = _wrap_strfunc(FakeFilesystem.readlink, os.readlink)
 
-    utime = _wrap_strfunc(FakeFilesystem.utime)
+    utime = _wrap_strfunc(FakeFilesystem.utime, os.utime)
 
 
 _fake_accessor = _FakeAccessor()
@@ -613,7 +603,6 @@ class FakePath(pathlib.Path):
 
         def _init(self, template=None):
             """Initializer called from base class."""
-            self._original_accessor = self._accessor
             # only needed until Python 3.10
             self._accessor = _fake_accessor
             # only needed until Python 3.8

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -452,7 +452,7 @@ def is_called_from_skipped_module(skip_names: list) -> bool:
         (
             frame.filename
             for frame in stack[::-1]
-            if not frame.filename.startswith("<frozen importlib")
+            if not frame.filename.startswith("<frozen ")
             and not frame.filename.startswith(STDLIB_PATH)
             and (
                 not frame.filename.startswith(PYFAKEFS_PATH)

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -1357,6 +1357,9 @@ class SkipPathlibTest(fake_filesystem_unittest.TestCase):
         contents = read_bytes_pathlib("skipped_pathlib.py")
         self.assertTrue(contents.startswith(b"# Licensed under the Apache License"))
 
+    @unittest.skipIf(
+        IS_PYPY and sys.version_info < (3, 8), "Ignoring error in outdated version"
+    )
     def test_exists(self):
         self.assertTrue(check_exists_pathlib())
 

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -34,6 +34,7 @@ from pyfakefs import fake_pathlib, fake_filesystem, fake_filesystem_unittest, fa
 from pyfakefs.fake_filesystem import OSType
 from pyfakefs.helpers import IS_PYPY, is_root
 from pyfakefs.tests.skipped_pathlib import (
+    check_exists_pathlib,
     read_bytes_pathlib,
     read_pathlib,
     read_text_pathlib,
@@ -1355,6 +1356,9 @@ class SkipPathlibTest(fake_filesystem_unittest.TestCase):
         # regression test for #1012
         contents = read_bytes_pathlib("skipped_pathlib.py")
         self.assertTrue(contents.startswith(b"# Licensed under the Apache License"))
+
+    def test_exists(self):
+        self.assertTrue(check_exists_pathlib())
 
 
 if __name__ == "__main__":

--- a/pyfakefs/tests/skipped_pathlib.py
+++ b/pyfakefs/tests/skipped_pathlib.py
@@ -29,6 +29,10 @@ def read_bytes_pathlib(file_name):
     return (Path(__file__).parent / file_name).read_bytes()
 
 
+def check_exists_pathlib():
+    return os.path.exists(__file__) and Path(__file__).exists()
+
+
 def read_open(file_name):
     with open(os.path.join(os.path.dirname(__file__), file_name)) as f:
         return f.read()


### PR DESCRIPTION
#### Describe the changes
Add a call stack check for fake filesystem, `os` and `os.path` methods in their `handle_original_call` wrapper to see if they are being called from a module listed in `skip_modules`.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
