### PR TITLE
Preliminary support for Python 3.13

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -3,6 +3,10 @@ name: Testsuite
 on:
   [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   pytype:
     runs-on: ubuntu-latest
@@ -28,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13-dev"]
         include:
           - python-version: "pypy-3.7"
             os: ubuntu-latest
@@ -53,7 +57,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-        echo "dir=$(pip cache dir)" >> $env:GITHUB_OUTPUT
 
     - name: Cache dependencies
       id: cache-dep
@@ -85,16 +88,20 @@ jobs:
         fi
       shell: bash
     - name: Install extra dependencies
-      if: ${{ matrix.python-version != 'pypy-3.10' }}
+      if: ${{ matrix.python-version != 'pypy-3.10' && ( matrix.python-version != '3.13-dev' || matrix.os != 'windows-latest' ) }}
       run: |
         pip install -r extra_requirements.txt
         pip install -r legacy_requirements.txt
-        pip install zstandard cffi  # needed to test #910
+        if [[ '${{ matrix.python-version }}' != '3.13-dev' ]]; then
+          pip install zstandard cffi  # needed to test #910
+        fi
       shell: bash
     - name: Run unit tests with extra packages as non-root user
-      if: ${{ matrix.python-version != 'pypy-3.10' }}
+      if: ${{ matrix.python-version != 'pypy-3.10' && ( matrix.python-version != '3.13-dev' || matrix.os != 'windows-latest' ) }}
       run: |
-        export PYTHON_ZSTANDARD_IMPORT_POLICY=cffi  # needed to test #910
+        if [[ '${{ matrix.python-version }}' != '3.13-dev' ]]; then
+          export PYTHON_ZSTANDARD_IMPORT_POLICY=cffi  # needed to test #910
+        fi
         python -m pyfakefs.tests.all_tests
       shell: bash
     - name: Run performance tests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,11 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
-### Fixes
+### Enhancements
+* added preliminary support for Python 3.13 (tested with beta2) (see [#1017](../../issues/1017))
 
-* Use real open calls for remaining `pathlib` functions so that it works nice with skippedmodules (see #1012)
+### Fixes
+* use real open calls for remaining `pathlib` functions so that it works nice with skippedmodules (see [#1012](../../issues/1012))
 
 ## [Version 5.5.0](https://pypi.python.org/pypi/pyfakefs/5.5.0) (2024-05-12)
 Deprecates the usage of `pathlib2` and `scandir`.

--- a/legacy_requirements.txt
+++ b/legacy_requirements.txt
@@ -5,4 +5,4 @@
 # Note that the usage of these modules is deprecated, and their support
 # will be removed in pyfakefs 6.0
 pathlib2>=2.3.2
-scandir>=1.8
+scandir>=1.8; python_version < '3.13'  # not (yet) available for Python 3.13

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -54,6 +54,7 @@ from pyfakefs.helpers import (
     AnyString,
     get_locale_encoding,
     _OpenModes,
+    is_root,
 )
 
 if TYPE_CHECKING:
@@ -587,7 +588,7 @@ class FakeDirectory(FakeFile):
         pathname_name = self._normalized_entryname(pathname_name)
         entry = self.get_entry(pathname_name)
         if self.filesystem.is_windows_fs:
-            if entry.st_mode & helpers.PERM_WRITE == 0:
+            if not is_root() and entry.st_mode & helpers.PERM_WRITE == 0:
                 self.filesystem.raise_os_error(errno.EACCES, pathname_name)
             if self.filesystem.has_open_file(entry):
                 raise_error = True

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -32,6 +32,7 @@ get the properties of the underlying fake filesystem.
 import errno
 import fnmatch
 import functools
+import glob
 import inspect
 import ntpath
 import os
@@ -39,6 +40,7 @@ import pathlib
 import posixpath
 import re
 import sys
+import warnings
 from pathlib import PurePath
 from typing import Callable, List
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
@@ -70,23 +72,25 @@ def init_module(filesystem):
         fake_pure_nt_flavour.altsep = "/"
         FakePathlibModule.PureWindowsPath._flavour = fake_pure_nt_flavour
     else:
-        # in Python 3.12, the flavour is no longer an own class,
+        # in Python > 3.11, the flavour is no longer a separate class,
         # but points to the os-specific path module (posixpath/ntpath)
         fake_os = FakeOsModule(filesystem)
-        FakePathlibModule.PosixPath._flavour = fake_os.path
-        FakePathlibModule.WindowsPath._flavour = fake_os.path
+        parser_name = "_flavour" if sys.version_info < (3, 13) else "parser"
+
+        setattr(FakePathlibModule.PosixPath, parser_name, fake_os.path)
+        setattr(FakePathlibModule.WindowsPath, parser_name, fake_os.path)
 
         # Pure POSIX path separators must be filesystem independent.
         fake_pure_posix_os = FakeOsModule(filesystem)
         fake_pure_posix_os.path.sep = "/"
         fake_pure_posix_os.path.altsep = None
-        FakePathlibModule.PurePosixPath._flavour = fake_pure_posix_os.path
+        setattr(FakePathlibModule.PurePosixPath, parser_name, fake_pure_posix_os.path)
 
         # Pure Windows path separators must be filesystem independent.
         fake_pure_nt_os = FakeOsModule(filesystem)
         fake_pure_nt_os.path.sep = "\\"
         fake_pure_nt_os.path.altsep = "/"
-        FakePathlibModule.PureWindowsPath._flavour = fake_pure_nt_os.path
+        setattr(FakePathlibModule.PureWindowsPath, parser_name, fake_pure_nt_os.path)
 
 
 def _wrap_strfunc(strfunc):
@@ -578,6 +582,15 @@ class FakePath(pathlib.Path):
             # only needed until Python 3.8
             self._closed = False
 
+    if sys.version_info >= (3, 13):
+
+        def _glob_selector(self, parts, case_sensitive, recurse_symlinks):
+            # make sure we get the patched version of the globber
+            self._globber = glob._StringGlobber  # type: ignore[module-attr]
+            return super()._glob_selector(  # type: ignore[attribute-error]
+                parts, case_sensitive, recurse_symlinks
+            )
+
     def _path(self):
         """Returns the underlying path string as used by the fake
         filesystem.
@@ -805,13 +818,22 @@ class FakePath(pathlib.Path):
             return os.path.isabs(self._path())
 
         def is_reserved(self):
-            if not self.filesystem.is_windows_fs or not self._tail:
+            if sys.version_info >= (3, 13):
+                warnings.warn(
+                    "pathlib.PurePath.is_reserved() is deprecated and scheduled "
+                    "for removal in Python 3.15. Use os.path.isreserved() to detect "
+                    "reserved paths on Windows.",
+                    DeprecationWarning,
+                )
+            if not self.filesystem.is_windows_fs:
                 return False
-            if self._tail[0].startswith("\\\\"):
-                # UNC paths are never reserved.
-                return False
-            name = self._tail[-1].partition(".")[0].partition(":")[0].rstrip(" ")
-            return name.upper() in pathlib._WIN_RESERVED_NAMES
+            if sys.version_info < (3, 13):
+                if not self._tail or self._tail[0].startswith("\\\\"):
+                    # UNC paths are never reserved.
+                    return False
+                name = self._tail[-1].partition(".")[0].partition(":")[0].rstrip(" ")
+                return name.upper() in pathlib._WIN_RESERVED_NAMES
+            return self.filesystem.isreserved(self._path())
 
 
 class FakePathlibModule:
@@ -837,11 +859,15 @@ class FakePathlibModule:
         paths"""
 
         __slots__ = ()
+        if sys.version_info >= (3, 13):
+            parser = posixpath
 
     class PureWindowsPath(PurePath):
         """A subclass of PurePath, that represents Windows filesystem paths"""
 
         __slots__ = ()
+        if sys.version_info >= (3, 13):
+            parser = ntpath
 
     class WindowsPath(FakePath, PureWindowsPath):
         """A subclass of Path and PureWindowsPath that represents
@@ -933,8 +959,10 @@ class RealPath(pathlib.Path):
             if os.name == "nt"
             else pathlib._PosixFlavour()  # type:ignore
         )  # type:ignore
-    else:
+    elif sys.version_info < (3, 13):
         _flavour = ntpath if os.name == "nt" else posixpath
+    else:
+        parser = ntpath if os.name == "nt" else posixpath
 
     def __new__(cls, *args, **kwargs):
         """Creates the correct subclass based on OS."""

--- a/pyfakefs/helpers.py
+++ b/pyfakefs/helpers.py
@@ -12,6 +12,7 @@
 
 """Helper classes use for fake file system implementation."""
 
+import ctypes
 import io
 import locale
 import os
@@ -44,8 +45,9 @@ _OpenModes = namedtuple(
 )
 
 if sys.platform == "win32":
-    USER_ID = 1
-    GROUP_ID = 1
+    fake_id = 0 if ctypes.windll.shell32.IsUserAnAdmin() else 1
+    USER_ID = fake_id
+    GROUP_ID = fake_id
 else:
     USER_ID = os.getuid()
     GROUP_ID = os.getgid()
@@ -87,8 +89,9 @@ def set_gid(gid: int) -> None:
 def reset_ids() -> None:
     """Set the global user ID and group ID back to default values."""
     if sys.platform == "win32":
-        set_uid(1)
-        set_gid(1)
+        reset_id = 0 if ctypes.windll.shell32.IsUserAnAdmin() else 1
+        set_uid(reset_id)
+        set_gid(reset_id)
     else:
         set_uid(os.getuid())
         set_gid(os.getgid())

--- a/pyfakefs/pytest_tests/pytest_reload_pandas_test.py
+++ b/pyfakefs/pytest_tests/pytest_reload_pandas_test.py
@@ -4,8 +4,12 @@ Ensures that reloading the `pandas.core.arrays.arrow.extension_types` module suc
 
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
 
 try:
     import parquet
@@ -13,14 +17,18 @@ except ImportError:
     parquet = None
 
 
-@pytest.mark.skipif(parquet is None, reason="parquet not installed")
+@pytest.mark.skipif(
+    pd is None or parquet is None, reason="pandas or parquet not installed"
+)
 def test_1(fs):
     dir_ = Path(__file__).parent / "data"
     fs.add_real_directory(dir_)
     pd.read_parquet(dir_ / "test.parquet")
 
 
-@pytest.mark.skipif(parquet is None, reason="parquet not installed")
+@pytest.mark.skipif(
+    pd is None or parquet is None, reason="pandas or parquet not installed"
+)
 def test_2():
     dir_ = Path(__file__).parent / "data"
     pd.read_parquet(dir_ / "test.parquet")

--- a/pyfakefs/tests/fake_filesystem_glob_test.py
+++ b/pyfakefs/tests/fake_filesystem_glob_test.py
@@ -14,8 +14,10 @@
 
 """Test for glob using fake_filesystem."""
 
+import contextlib
 import glob
 import os
+import sys
 import unittest
 
 from pyfakefs import fake_filesystem_unittest
@@ -71,7 +73,12 @@ class FakeGlobUnitTest(fake_filesystem_unittest.TestCase):
         self.assertEqual(["/[Temp]"], glob.glob("/*emp*"))
 
     def test_glob1(self):
-        self.assertEqual(["[Temp]"], glob.glob1("/", "*Tem*"))
+        with (
+            contextlib.nullcontext()
+            if sys.version_info < (3, 13)
+            else self.assertWarns(DeprecationWarning)
+        ):
+            self.assertEqual(["[Temp]"], glob.glob1("/", "*Tem*"))
 
     def test_has_magic(self):
         self.assertTrue(glob.has_magic("["))

--- a/pyfakefs/tests/test_utils.py
+++ b/pyfakefs/tests/test_utils.py
@@ -269,32 +269,18 @@ class RealFsTestMixin:
                     "Skipping because FakeFS does not match real FS"
                 )
 
-    def symlink_can_be_tested(self, force_real_fs=False):
+    def symlink_can_be_tested(self):
         """Used to check if symlinks and hard links can be tested under
         Windows. All tests are skipped under Windows for Python versions
         not supporting links, and real tests are skipped if running without
         administrator rights.
         """
-        if not TestCase.is_windows or (not force_real_fs and not self.use_real_fs()):
-            return True
-        if TestCase.symlinks_can_be_tested is None:
-            if force_real_fs:
-                self.base_path = tempfile.mkdtemp()
-            link_path = self.make_path("link")
-            try:
-                self.os.symlink(self.base_path, link_path)
-                TestCase.symlinks_can_be_tested = True
-                self.os.remove(link_path)
-            except (OSError, NotImplementedError):
-                TestCase.symlinks_can_be_tested = False
-            if force_real_fs:
-                self.base_path = None
-        return TestCase.symlinks_can_be_tested
+        return not TestCase.is_windows or is_root()
 
-    def skip_if_symlink_not_supported(self, force_real_fs=False):
+    def skip_if_symlink_not_supported(self):
         """If called at test start, tests are skipped if symlinks are not
         supported."""
-        if not self.symlink_can_be_tested(force_real_fs):
+        if not self.symlink_can_be_tested():
             raise unittest.SkipTest("Symlinks under Windows need admin privileges")
 
     def make_path(self, *args):


### PR DESCRIPTION
- account for changes in pathlib implementation
- reload glob to account for changed implementation
- improve handling of admin user under Windows
- add os.isreserved
- change os.path.isabs under Windows
- add worksaround for recursion with linecache
- exclude extra dependencies tests for 3.13 under Windows (pandas not available yet)

Fixes #1017.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
