### PR TITLE
Use pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,14 @@ default_language_version:
   python: "3.10"
 
 repos:
+  - repo: "https://github.com/asottile/pyupgrade"
+    rev: "v3.15.2"
+    hooks:
+      - id: "pyupgrade"
+        name: "Enforce Python 3.7+ idioms"
+        args:
+          - "--py37-plus"
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.5.0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: 1.18.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [ black==22.12.0 ]
+        additional_dependencies: [ black==24.4.2 ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ The released versions correspond to PyPI releases.
 ### Fixes
 * use real open calls for remaining `pathlib` functions so that it works nice with skippedmodules (see [#1012](../../issues/1012))
 
+### Infrastructure
+* Add pyupgrade as a pre-commit hook.
+
 ## [Version 5.5.0](https://pypi.python.org/pypi/pyfakefs/5.5.0) (2024-05-12)
 Deprecates the usage of `pathlib2` and `scandir`.
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -349,7 +349,8 @@ If you want to know if your problem is indeed with the dynamic patcher, you can 
           yield
 
 
-  def test_something(fs_no_dyn_patch): ...  # do the testing
+  def test_something(fs_no_dyn_patch):
+      assert foo()  # do the testing
 
 If in this case the following tests pass as expected, the dynamic patcher is indeed the problem.
 If your ``pyfakefs`` test also works with that setting, you may just use this. Otherwise,

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -349,8 +349,7 @@ If you want to know if your problem is indeed with the dynamic patcher, you can 
           yield
 
 
-  def test_something(fs_no_dyn_patch):
-      ...  # do the testing
+  def test_something(fs_no_dyn_patch): ...  # do the testing
 
 If in this case the following tests pass as expected, the dynamic patcher is indeed the problem.
 If your ``pyfakefs`` test also works with that setting, you may just use this. Otherwise,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -179,12 +179,14 @@ order, as shown here:
 
    @patchfs
    @mock.patch("foo.bar")
-   def test_something(fake_fs, mocked_bar): ...
+   def test_something(fake_fs, mocked_bar):
+       assert foo()
 
 
    @mock.patch("foo.bar")
    @patchfs
-   def test_something(mocked_bar, fake_fs): ...
+   def test_something(mocked_bar, fake_fs):
+       assert foo()
 
 .. note::
   Avoid writing the ``patchfs`` decorator *between* ``mock.patch`` operators,
@@ -254,7 +256,8 @@ In case of ``pytest``, you have two possibilities:
           yield patcher.fs
 
 
-  def test_something(fs_no_root): ...
+  def test_something(fs_no_root):
+      assert foo()
 
 - You can also pass the arguments using ``@pytest.mark.parametrize``. Note that
   you have to provide `all Patcher arguments`_ before the needed ones, as
@@ -268,7 +271,8 @@ In case of ``pytest``, you have two possibilities:
 
 
   @pytest.mark.parametrize("fs", [[None, None, None, False]], indirect=True)
-  def test_something(fs): ...
+  def test_something(fs):
+      assert foo()
 
 Unittest
 ........
@@ -285,7 +289,8 @@ instance:
       def setUp(self):
           self.setUpPyfakefs(allow_root_user=False)
 
-      def testSomething(self): ...
+      def testSomething(self):
+          assert foo()
 
 patchfs
 .......
@@ -298,7 +303,8 @@ the decorator:
 
 
   @patchfs(allow_root_user=False)
-  def test_something(fake_fs): ...
+  def test_something(fake_fs):
+      assert foo()
 
 
 List of custom arguments
@@ -500,19 +506,22 @@ has now been been integrated into ``pyfakefs``):
       def setUp(self):
           self.setUpPyfakefs(modules_to_patch={"django.core.files.locks": FakeLocks})
 
-      def test_django_stuff(self): ...
+      def test_django_stuff(self):
+          assert foo()
 
 
   # test code using pytest
   @pytest.mark.parametrize(
       "fs", [[None, None, {"django.core.files.locks": FakeLocks}]], indirect=True
   )
-  def test_django_stuff(fs): ...
+  def test_django_stuff(fs):
+      assert foo()
 
 
   # test code using patchfs decorator
   @patchfs(modules_to_patch={"django.core.files.locks": FakeLocks})
-  def test_django_stuff(fake_fs): ...
+  def test_django_stuff(fake_fs):
+      assert foo()
 
 additional_skip_names
 .....................
@@ -575,7 +584,8 @@ set ``patch_open_code`` to ``PatchMode.AUTO``:
 
 
   @patchfs(patch_open_code=PatchMode.AUTO)
-  def test_something(fs): ...
+  def test_something(fs):
+      assert foo()
 
 .. _patch_default_args:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -179,14 +179,12 @@ order, as shown here:
 
    @patchfs
    @mock.patch("foo.bar")
-   def test_something(fake_fs, mocked_bar):
-       ...
+   def test_something(fake_fs, mocked_bar): ...
 
 
    @mock.patch("foo.bar")
    @patchfs
-   def test_something(mocked_bar, fake_fs):
-       ...
+   def test_something(mocked_bar, fake_fs): ...
 
 .. note::
   Avoid writing the ``patchfs`` decorator *between* ``mock.patch`` operators,
@@ -256,8 +254,7 @@ In case of ``pytest``, you have two possibilities:
           yield patcher.fs
 
 
-  def test_something(fs_no_root):
-      ...
+  def test_something(fs_no_root): ...
 
 - You can also pass the arguments using ``@pytest.mark.parametrize``. Note that
   you have to provide `all Patcher arguments`_ before the needed ones, as
@@ -271,8 +268,7 @@ In case of ``pytest``, you have two possibilities:
 
 
   @pytest.mark.parametrize("fs", [[None, None, None, False]], indirect=True)
-  def test_something(fs):
-      ...
+  def test_something(fs): ...
 
 Unittest
 ........
@@ -289,8 +285,7 @@ instance:
       def setUp(self):
           self.setUpPyfakefs(allow_root_user=False)
 
-      def testSomething(self):
-          ...
+      def testSomething(self): ...
 
 patchfs
 .......
@@ -303,8 +298,7 @@ the decorator:
 
 
   @patchfs(allow_root_user=False)
-  def test_something(fake_fs):
-      ...
+  def test_something(fake_fs): ...
 
 
 List of custom arguments
@@ -412,6 +406,7 @@ the file ``example/sut.py``, the following code will work (imports are omitted):
 
   import example
 
+
   # example using unittest
   class ReloadModuleTest(fake_filesystem_unittest.TestCase):
       def setUp(self):
@@ -499,27 +494,25 @@ has now been been integrated into ``pyfakefs``):
   with Patcher(modules_to_patch={"django.core.files.locks": FakeLocks}):
       test_django_stuff()
 
+
   # test code using unittest
   class TestUsingDjango(fake_filesystem_unittest.TestCase):
       def setUp(self):
           self.setUpPyfakefs(modules_to_patch={"django.core.files.locks": FakeLocks})
 
-      def test_django_stuff(self):
-          ...
+      def test_django_stuff(self): ...
 
 
   # test code using pytest
   @pytest.mark.parametrize(
       "fs", [[None, None, {"django.core.files.locks": FakeLocks}]], indirect=True
   )
-  def test_django_stuff(fs):
-      ...
+  def test_django_stuff(fs): ...
 
 
   # test code using patchfs decorator
   @patchfs(modules_to_patch={"django.core.files.locks": FakeLocks})
-  def test_django_stuff(fake_fs):
-      ...
+  def test_django_stuff(fake_fs): ...
 
 additional_skip_names
 .....................
@@ -582,8 +575,7 @@ set ``patch_open_code`` to ``PatchMode.AUTO``:
 
 
   @patchfs(patch_open_code=PatchMode.AUTO)
-  def test_something(fs):
-      ...
+  def test_something(fs): ...
 
 .. _patch_default_args:
 

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -60,6 +60,10 @@ from pyfakefs.helpers import (
 if TYPE_CHECKING:
     from pyfakefs.fake_filesystem import FakeFilesystem
 
+
+# Work around pyupgrade auto-rewriting `io.open()` to `open()`.
+io_open = io.open
+
 AnyFileWrapper = Union[
     "FakeFileWrapper",
     "FakeDirWrapper",
@@ -458,7 +462,7 @@ class FakeFileFromRealFile(FakeFile):
     def byte_contents(self) -> Optional[bytes]:
         if not self.contents_read:
             self.contents_read = True
-            with io.open(self.file_path, "rb") as f:
+            with io_open(self.file_path, "rb") as f:
                 self._byte_contents = f.read()
         # On MacOS and BSD, the above io.open() updates atime on the real file
         self.st_atime = os.stat(self.file_path).st_atime

--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -54,6 +54,9 @@ if TYPE_CHECKING:
     from pyfakefs.fake_filesystem import FakeFilesystem
 
 
+# Work around pyupgrade auto-rewriting `io.open()` to `open()`.
+io_open = io.open
+
 _OPEN_MODE_MAP = {
     # mode name:(file must exist, can read, can write,
     #            truncate, append, must not exist)
@@ -74,7 +77,7 @@ def _real_call_line_no():
     global real_call_line_no
     if real_call_line_no is None:
         fake_io_source = os.path.join(os.path.dirname(__file__), "fake_io.py")
-        for i, line in enumerate(io.open(fake_io_source)):
+        for i, line in enumerate(io_open(fake_io_source)):
             if "return self._io_module.open_code(path)" in line:
                 real_call_line_no = i + 1
                 break
@@ -105,7 +108,7 @@ def fake_open(
         and file.endswith(("fake_open.py", "fake_io.py"))
         and os.path.split(os.path.dirname(file))[1] == "pyfakefs"
     ):
-        return io.open(  # pytype: disable=wrong-arg-count
+        return io_open(  # pytype: disable=wrong-arg-count
             file,
             mode,
             buffering,
@@ -155,7 +158,7 @@ def fake_open(
     if from_open_code or any(
         [module_name == sn or module_name.endswith("." + sn) for sn in skip_names]
     ):
-        return io.open(  # pytype: disable=wrong-arg-count
+        return io_open(  # pytype: disable=wrong-arg-count
             file,
             mode,
             buffering,

--- a/pyfakefs/tests/example_test.py
+++ b/pyfakefs/tests/example_test.py
@@ -36,6 +36,10 @@ from pyfakefs.legacy_packages import scandir
 from pyfakefs.tests import example  # The module under test
 
 
+# Work around pyupgrade auto-rewriting `io.open()` to `open()`.
+io_open = io.open
+
+
 def load_tests(loader, tests, ignore):
     """Load the pyfakefs/example.py doctest tests into unittest."""
     return fake_filesystem_unittest.load_doctests(loader, tests, ignore, example)
@@ -62,7 +66,7 @@ class TestExample(fake_filesystem_unittest.TestCase):  # pylint: disable=R0904
 
         # This is before setUpPyfakefs(), so still using the real file system
         self.filepath = os.path.realpath(__file__)
-        with io.open(self.filepath, "rb") as f:
+        with io_open(self.filepath, "rb") as f:
             self.real_contents = f.read()
 
         self.setUpPyfakefs()

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -52,6 +52,10 @@ if sys.version_info < (3, 12):
     from distutils.dir_util import copy_tree, remove_tree
 
 
+# Work around pyupgrade auto-rewriting `io.open()` to `open()`.
+io_open = io.open
+
+
 class TestPatcher(TestCase):
     def test_context_manager(self):
         with Patcher() as patcher:
@@ -115,7 +119,7 @@ class TestPyfakefsUnittest(TestPyfakefsUnittestBase):  # pylint: disable=R0904
     def test_io_open(self):
         """Fake io module is bound"""
         self.assertFalse(os.path.exists("/fake_file.txt"))
-        with io.open("/fake_file.txt", "w", encoding="utf8") as f:
+        with io_open("/fake_file.txt", "w", encoding="utf8") as f:
             f.write("This test file was created using the" " io.open() function.\n")
         self.assertTrue(self.fs.exists("/fake_file.txt"))
         with open("/fake_file.txt", encoding="utf8") as f:


### PR DESCRIPTION
This PR introduces the following changes:

* Immunized usage of `io.open()` so it doesn't get rewritten by pyupgrade
* Ran `upadup` to update pre-commit hooks' `additional_dependencies`
* Ran `pre-commit run -a` to fix the docs based on a much newer black version used by blacken-docs
* Added pyupgrade as a pre-commit hook, with Python 3.7+ idioms enforced


Closes #1020

<!--
Please prefix your PR title with [WIP] for PRs that are still in progress.
-->

#### Describe the changes
The related issue or a description of the bug or feature that this PR addresses.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [ ] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
