### PR TITLE
Add apply_umask argument to FakeFilesystem.create_dir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,22 @@
 # pyfakefs Release Notes
 The released versions correspond to PyPI releases.
 
+## Policy for Python version support
+* support for new versions is usually added preliminarily during the Python release beta phase,
+  official support after the final release
+* support for EOL versions is removed as soon as the CI (GitHub actions) does no longer provide
+  these versions (usually several months after the official EOL)
+
 ## Planned changes for next major release (6.0.0)
-* remove support for patching legacy modules `scandir` and `pathlib2`
-* remove support for Python 3.7
+* support for patching legacy modules `scandir` and `pathlib2` will be removed
+* the default for `FakeFilesystem.shuffle_listdir_results` will change to `True` to reflect
+  the real filesystem behavior
 
 ## Unreleased
 
 ### Enhancements
 * added preliminary support for Python 3.13 (tested with beta2) (see [#1017](../../issues/1017))
+* added `apply_umask` argument to `FakeFilesystem.create_dir` to allow ignoring the umask (see [#1038](../../issues/1038))
 
 ### Fixes
 * use real open calls for remaining `pathlib` functions so that it works nice with skippedmodules (see [#1012](../../issues/1012))

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -515,6 +515,20 @@ class FakeFilesystemUnitTest(TestCase):
         self.assertEqual(os.path.basename(path), new_dir.name)
         self.assertTrue(stat.S_IFDIR & new_dir.st_mode)
 
+    def test_create_dir_umask(self):
+        old_umask = self.filesystem.umask
+        self.filesystem.umask = 0o22
+        path = "foo/bar/baz"
+        self.filesystem.create_dir(path, perm_bits=0o777)
+        new_dir = self.filesystem.get_object(path)
+        self.assertEqual(stat.S_IFDIR | 0o755, new_dir.st_mode)
+
+        path = "foo/bar/boo"
+        self.filesystem.create_dir(path, perm_bits=0o777, apply_umask=False)
+        new_dir = self.filesystem.get_object(path)
+        self.assertEqual(stat.S_IFDIR | 0o777, new_dir.st_mode)
+        self.filesystem.umask = old_umask
+
     def test_create_directory_already_exists_error(self):
         path = "foo/bar/baz"
         self.filesystem.create_dir(path)


### PR DESCRIPTION
* allows to ignore the umask
* closes #1038

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
