### PR TITLE
Patch linecache in Python 3.13

### DIFF
--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -70,19 +70,6 @@ _OPEN_MODE_MAP = {
     "x+": (False, True, True, False, False, True),
 }
 
-real_call_line_no = None
-
-
-def _real_call_line_no():
-    global real_call_line_no
-    if real_call_line_no is None:
-        fake_io_source = os.path.join(os.path.dirname(__file__), "fake_io.py")
-        for i, line in enumerate(io_open(fake_io_source)):
-            if "return self._io_module.open_code(path)" in line:
-                real_call_line_no = i + 1
-                break
-    return real_call_line_no
-
 
 def fake_open(
     filesystem: "FakeFilesystem",
@@ -99,25 +86,6 @@ def fake_open(
     """Redirect the call to FakeFileOpen.
     See FakeFileOpen.call() for description.
     """
-    # since Python 3.13, we can run into a recursion in some instances here:
-    # traceback calls linecache.update_cache, which loads 'os' dynamically,
-    # which will be patched by the dynamic patcher and ends up here again;
-    # for these instances, we use a shortcut check here
-    if (
-        isinstance(file, str)
-        and file.endswith(("fake_open.py", "fake_io.py"))
-        and os.path.split(os.path.dirname(file))[1] == "pyfakefs"
-    ):
-        return io_open(  # pytype: disable=wrong-arg-count
-            file,
-            mode,
-            buffering,
-            encoding,
-            errors,
-            newline,
-            closefd,
-            opener,
-        )
 
     # workaround for built-in open called from skipped modules (see #552)
     # as open is not imported explicitly, we cannot patch it for
@@ -127,13 +95,8 @@ def fake_open(
 
     # handle the case that we try to call the original `open_code`
     # and get here instead (since Python 3.12)
-    # TODO: use a more generic approach (see other PR #1025)
-    if sys.version_info >= (3, 13):
-        # TODO: check if stacktrace line is still not filled in final version
-        from_open_code = (
-            stack[0].name == "open_code" and stack[0].lineno == _real_call_line_no()
-        )
-    elif sys.version_info >= (3, 12):
+    # TODO: use a more generic approach (see PR #1025)
+    if sys.version_info >= (3, 12):
         from_open_code = (
             stack[0].name == "open_code"
             and stack[0].line == "return self._io_module.open_code(path)"


### PR DESCRIPTION
- replaces previous workaround that somewhat broke the linecache
- needed because os is now imported locally

#### Tasks
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
