### PR TITLE
Add support for os.fchmod

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,8 +15,9 @@ The released versions correspond to PyPI releases.
 ## Unreleased
 
 ### Enhancements
-
-- refactor the implementation of `additional_skip_names` parameter to make it work with more modules (see [#1023](../../issues/1023))
+* the `additional_skip_names` parameter now works with more modules (see [#1023](../../issues/1023))
+* added support for `os.fchmod`, allow file descriptor argument for `os.chmod` only for POSIX
+  for Python < 3.13
 
 ## [Version 5.6.0](https://pypi.python.org/pypi/pyfakefs/5.6.0) (2024-07-12)
 Adds preliminary Python 3.13 support.

--- a/pyfakefs/fake_os.py
+++ b/pyfakefs/fake_os.py
@@ -210,7 +210,7 @@ class FakeOsModule:
             return 0o002
         else:
             # under Unix, we return the real umask;
-            # as there is no pure getter for umask, so we have to first
+            # there is no pure getter for umask, so we have to first
             # set a mode to get the previous one and then re-set that
             mask = os.umask(0)
             os.umask(mask)
@@ -1054,6 +1054,23 @@ class FakeOsModule:
         if is_root():
             mode &= ~os.W_OK
         return (mode & ((stat_result.st_mode >> 6) & 7)) == mode
+
+    def fchmod(
+        self,
+        fd: int,
+        mode: int,
+    ) -> None:
+        """Change the permissions of an open file as encoded in integer mode.
+
+        Args:
+            fd: (int) File descriptor.
+            mode: (int) Permissions.
+        """
+        if self.filesystem.is_windows_fs and sys.version_info < (3, 13):
+            raise AttributeError(
+                "module 'os' has no attribute 'fchmod'. " "Did you mean: 'chmod'?"
+            )
+        self.filesystem.chmod(fd, mode)
 
     def chmod(
         self,


### PR DESCRIPTION
- restrict availability for fd argument in os.chmod (not available in Windows for Python < 3.13)

Noticed this while checking the changes in Python 3.13 - we don't support `os.fchmod` so far.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
