### PR TITLE
Avoid reloading glob in Python 3.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,12 @@ The released versions correspond to PyPI releases.
 * the `additional_skip_names` parameter now works with more modules (see [#1023](../../issues/1023))
 * added support for `os.fchmod`, allow file descriptor argument for `os.chmod` only for POSIX
   for Python < 3.13
+* avoid reloading `glob` in Python 3.13 (did affect test performance)
 
 ### Fixes
 * removing files while iterating over `scandir` results is now possible (see [#1051](../../issues/1051))
 * fake `pathlib.PosixPath` and `pathlib.WindowsPath` now behave more like in the real filesystem
-  (see [#1055](../../issues/1055))
+  (see [#1053](../../issues/1053))
 
 ## [Version 5.6.0](https://pypi.python.org/pypi/pyfakefs/5.6.0) (2024-07-12)
 Adds preliminary Python 3.13 support.

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -32,7 +32,6 @@ get the properties of the underlying fake filesystem.
 import errno
 import fnmatch
 import functools
-import glob
 import inspect
 import ntpath
 import os
@@ -639,15 +638,6 @@ class FakePath(pathlib.Path):
             self._accessor = _fake_accessor
             # only needed until Python 3.8
             self._closed = False
-
-    if sys.version_info >= (3, 13):
-
-        def _glob_selector(self, parts, case_sensitive, recurse_symlinks):
-            # make sure we get the patched version of the globber
-            self._globber = glob._StringGlobber  # type: ignore[module-attr]
-            return super()._glob_selector(  # type: ignore[attribute-error]
-                parts, case_sensitive, recurse_symlinks
-            )
 
     def _path(self):
         """Returns the underlying path string as used by the fake

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -822,11 +822,11 @@ class FakePathlibPathFileOperationTest(RealPathlibTestCase):
         self.create_file(self.make_path("foo", "setup.pyc"))
         path = self.path(self.make_path("foo"))
         self.assertEqual(
-            sorted(path.glob("*.py")),
             [
                 self.path(self.make_path("foo", "all_tests.py")),
                 self.path(self.make_path("foo", "setup.py")),
             ],
+            sorted(path.glob("*.py")),
         )
 
     @unittest.skipIf(not is_windows, "Windows specific test")
@@ -837,12 +837,12 @@ class FakePathlibPathFileOperationTest(RealPathlibTestCase):
         self.create_file(self.make_path("foo", "example.Py"))
         path = self.path(self.make_path("foo"))
         self.assertEqual(
-            sorted(path.glob("*.py")),
             [
                 self.path(self.make_path("foo", "all_tests.PY")),
                 self.path(self.make_path("foo", "example.Py")),
                 self.path(self.make_path("foo", "setup.py")),
             ],
+            sorted(path.glob("*.py")),
         )
 
     @unittest.skipIf(is_windows, "Posix specific test")


### PR DESCRIPTION
- patch glob instead
- avoids performance hit on tests

#### Tasks
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
