### PR TITLE
Forward unfaked fcntl calls to real module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,11 @@ The released versions correspond to PyPI releases.
 * the default for `FakeFilesystem.shuffle_listdir_results` will change to `True` to reflect
   the real filesystem behavior
 
+## Unreleased
+
+### Fixes
+* fixes a regression that caused unfaked `fcntl` calls to fail (see [#1074](../../issues/1074))
+
 ## [Version 5.7.0](https://pypi.python.org/pypi/pyfakefs/5.7.0) (2024-08-10)
 Adds official Python 3.13 support, improves OS emulation behavior.
 

--- a/pyfakefs/fake_io.py
+++ b/pyfakefs/fake_io.py
@@ -181,7 +181,7 @@ if sys.platform != "win32":
             pass
 
         def __getattribute__(self, name):
-            """Forwards any unfaked calls to the standard fcntl module."""
+            """Prevents patching of skipped modules."""
             fs: FakeFilesystem = object.__getattribute__(self, "filesystem")
             fnctl_module = object.__getattribute__(self, "_fcntl_module")
             if fs.patcher:
@@ -193,3 +193,7 @@ if sys.platform != "win32":
                     return getattr(fnctl_module, name)
 
             return object.__getattribute__(self, name)
+
+        def __getattr__(self, name):
+            """Forwards any unfaked calls to the standard fcntl module."""
+            return getattr(self._fcntl_module, name)

--- a/pyfakefs/pytest_tests/fake_fcntl_test.py
+++ b/pyfakefs/pytest_tests/fake_fcntl_test.py
@@ -1,0 +1,22 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+if sys.platform == "linux":
+    import fcntl
+
+    def test_unpatched_attributes_are_forwarded_to_real_fs(fs):
+        # regression test for #1074
+        with open("lock_file", "a+") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_SH)
+            fcntl.flock(lock_file, fcntl.LOCK_UN)


### PR DESCRIPTION
- had been removed accidentally in 5.7.0
- fixes #1074

<!--
Please prefix your PR title with [WIP] for PRs that are still in progress.
-->

While adding support for skipped modules, the forwarding of unfaked attributes to the real fcntl module had been removed accidentally.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
