### PR TITLE
Performance: do not reload tempfile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Performance
+* avoid reloading `tempfile` in Posix systems
+
 ### Infrastructure
 * use trusted publisher for release (see https://docs.pypi.org/trusted-publishers/)
 
@@ -33,7 +36,9 @@ Adds official Python 3.13 support, improves OS emulation behavior.
 * the `additional_skip_names` parameter now works with more modules (see [#1023](../../issues/1023))
 * added support for `os.fchmod`, allow file descriptor argument for `os.chmod` only for POSIX
   for Python < 3.13
-* avoid reloading `glob` in Python 3.13 (did affect test performance)
+
+### Performance
+* avoid reloading `glob` in Python 3.13
 
 ### Fixes
 * removing files while iterating over `scandir` results is now possible (see [#1051](../../issues/1051))
@@ -574,6 +579,8 @@ release.
     default to avoid a large performance impact. An additional parameter
     `patch_default_args` has been added that switches this behavior on
     (see [#567](../../issues/567)).
+
+### Performance
   * Added performance improvements in the test setup, including caching the
     unpatched modules
 

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -541,12 +541,7 @@ class NoRootUserTest(fake_filesystem_unittest.TestCase):
 
 class PauseResumeTest(fake_filesystem_unittest.TestCase):
     def setUp(self):
-        self.real_temp_file = None
         self.setUpPyfakefs()
-
-    def tearDown(self):
-        if self.real_temp_file is not None:
-            self.real_temp_file.close()
 
     def test_pause_resume(self):
         fake_temp_file = tempfile.NamedTemporaryFile()
@@ -555,11 +550,11 @@ class PauseResumeTest(fake_filesystem_unittest.TestCase):
         self.pause()
         self.assertTrue(self.fs.exists(fake_temp_file.name))
         self.assertFalse(os.path.exists(fake_temp_file.name))
-        self.real_temp_file = tempfile.NamedTemporaryFile()
-        self.assertFalse(self.fs.exists(self.real_temp_file.name))
-        self.assertTrue(os.path.exists(self.real_temp_file.name))
+        real_temp_file = tempfile.NamedTemporaryFile()
+        self.assertFalse(self.fs.exists(real_temp_file.name))
+        self.assertTrue(os.path.exists(real_temp_file.name))
         self.resume()
-        self.assertFalse(os.path.exists(self.real_temp_file.name))
+        self.assertFalse(os.path.exists(real_temp_file.name))
         self.assertTrue(os.path.exists(fake_temp_file.name))
 
     def test_pause_resume_fs(self):
@@ -572,15 +567,15 @@ class PauseResumeTest(fake_filesystem_unittest.TestCase):
         self.fs.pause()
         self.assertTrue(self.fs.exists(fake_temp_file.name))
         self.assertFalse(os.path.exists(fake_temp_file.name))
-        self.real_temp_file = tempfile.NamedTemporaryFile()
-        self.assertFalse(self.fs.exists(self.real_temp_file.name))
-        self.assertTrue(os.path.exists(self.real_temp_file.name))
+        real_temp_file = tempfile.NamedTemporaryFile()
+        self.assertFalse(self.fs.exists(real_temp_file.name))
+        self.assertTrue(os.path.exists(real_temp_file.name))
         # pause does nothing if already paused
         self.fs.pause()
-        self.assertFalse(self.fs.exists(self.real_temp_file.name))
-        self.assertTrue(os.path.exists(self.real_temp_file.name))
+        self.assertFalse(self.fs.exists(real_temp_file.name))
+        self.assertTrue(os.path.exists(real_temp_file.name))
         self.fs.resume()
-        self.assertFalse(os.path.exists(self.real_temp_file.name))
+        self.assertFalse(os.path.exists(real_temp_file.name))
         self.assertTrue(os.path.exists(fake_temp_file.name))
 
     def test_pause_resume_contextmanager(self):
@@ -590,10 +585,10 @@ class PauseResumeTest(fake_filesystem_unittest.TestCase):
         with Pause(self):
             self.assertTrue(self.fs.exists(fake_temp_file.name))
             self.assertFalse(os.path.exists(fake_temp_file.name))
-            self.real_temp_file = tempfile.NamedTemporaryFile()
-            self.assertFalse(self.fs.exists(self.real_temp_file.name))
-            self.assertTrue(os.path.exists(self.real_temp_file.name))
-        self.assertFalse(os.path.exists(self.real_temp_file.name))
+            real_temp_file = tempfile.NamedTemporaryFile()
+            self.assertFalse(self.fs.exists(real_temp_file.name))
+            self.assertTrue(os.path.exists(real_temp_file.name))
+        self.assertFalse(os.path.exists(real_temp_file.name))
         self.assertTrue(os.path.exists(fake_temp_file.name))
 
     def test_pause_resume_fs_contextmanager(self):
@@ -603,10 +598,10 @@ class PauseResumeTest(fake_filesystem_unittest.TestCase):
         with Pause(self.fs):
             self.assertTrue(self.fs.exists(fake_temp_file.name))
             self.assertFalse(os.path.exists(fake_temp_file.name))
-            self.real_temp_file = tempfile.NamedTemporaryFile()
-            self.assertFalse(self.fs.exists(self.real_temp_file.name))
-            self.assertTrue(os.path.exists(self.real_temp_file.name))
-        self.assertFalse(os.path.exists(self.real_temp_file.name))
+            real_temp_file = tempfile.NamedTemporaryFile()
+            self.assertFalse(self.fs.exists(real_temp_file.name))
+            self.assertTrue(os.path.exists(real_temp_file.name))
+        self.assertFalse(os.path.exists(real_temp_file.name))
         self.assertTrue(os.path.exists(fake_temp_file.name))
 
     def test_pause_resume_without_patcher(self):

--- a/pyfakefs/tests/performance_test.py
+++ b/pyfakefs/tests/performance_test.py
@@ -61,10 +61,10 @@ if os.environ.get("TEST_PERFORMANCE"):
         """
 
         def test_cached_time(self):
-            self.assertLess(SetupPerformanceTest.elapsed_time, 0.4)
+            self.assertLess(SetupPerformanceTest.elapsed_time, 0.18)
 
         def test_uncached_time(self):
-            self.assertLess(SetupNoCachePerformanceTest.elapsed_time, 6)
+            self.assertLess(SetupNoCachePerformanceTest.elapsed_time, 4)
 
     def test_setup(self):
         pass


### PR DESCRIPTION
- patch tempfile instead directly (Posix only)

Reload takes between 0.5 and 1 ms, which is a substantial part of the test setup, as no caching can be done here.
This made the setup under Posix slower than under Windows.

#### Tasks
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
