### PR TITLE
Add some support for loading fake modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Enhancements
+* added some support for loading fake modules in `AUTO` patch mode
+  using `importlib.import_module` (see [#1079](../../issues/1079))
+
 ### Performance
 * avoid reloading `tempfile` in Posix systems
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -587,6 +587,20 @@ set ``patch_open_code`` to ``PatchMode.AUTO``:
   def test_something(fs):
       assert foo()
 
+In this mode, it is also possible to import modules created in the fake filesystem
+using `importlib.import_module`. Make sure that the `sys.path` contains the parent path in this case:
+
+.. code:: python
+
+  @patchfs(patch_open_code=PatchMode.AUTO)
+  def test_fake_import(fs):
+      fake_module_path = Path("/") / "site-packages" / "fake_module.py"
+      self.fs.create_file(fake_module_path, contents="x = 5")
+      sys.path.insert(0, str(fake_module_path.parent))
+      module = importlib.import_module("fake_module")
+      assert module.x == 5
+
+
 .. _patch_default_args:
 
 patch_default_args


### PR DESCRIPTION
 - works only if open_code patch mode is not off
 - see #1079

This will not handle all possible cases. Relative imports are not supported, and for absolute imports in dot notation an `__init__.py` is expected in module paths above the leaf module.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
