### PR TITLE
Add checks to avoid patching debugger modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ The released versions correspond to PyPI releases.
 ### Enhancements
 * added some support for loading fake modules in `AUTO` patch mode
   using `importlib.import_module` (see [#1079](../../issues/1079))
+* added some support to avoid patching debugger related modules
+  (see [#1083](../../issues/1083))
 
 ### Performance
 * avoid reloading `tempfile` in Posix systems

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -456,6 +456,36 @@ class AdditionalSkipNamesModuleTest(fake_filesystem_unittest.TestCase):
         pyfakefs.tests.import_as_example.return_this_file_path()
 
 
+class RuntimeSkipModuleTest(fake_filesystem_unittest.TestCase):
+    """Emulates skipping a module using RUNTIME_SKIPMODULES.
+    Not all functionality implemented for skip modules will work here."""
+
+    def setUp(self):
+        Patcher.RUNTIME_SKIPMODULES.update(
+            {"pyfakefs.tests.import_as_example": ["pyfakefs.tests.import_"]}
+        )
+        self.setUpPyfakefs()
+
+    def tearDown(self):
+        del self.patcher.RUNTIME_SKIPMODULES["pyfakefs.tests.import_as_example"]
+
+    def test_fake_path_does_not_exist1(self):
+        self.fs.create_file("foo")
+        self.assertFalse(pyfakefs.tests.import_as_example.check_if_exists1("foo"))
+
+    def test_fake_path_does_not_exist2(self):
+        self.fs.create_file("foo")
+        self.assertFalse(pyfakefs.tests.import_as_example.check_if_exists2("foo"))
+
+    def test_fake_path_does_not_exist3(self):
+        self.fs.create_file("foo")
+        self.assertFalse(pyfakefs.tests.import_as_example.check_if_exists3("foo"))
+
+    def test_fake_path_does_not_exist4(self):
+        self.fs.create_file("foo")
+        self.assertFalse(pyfakefs.tests.import_as_example.check_if_exists4("foo"))
+
+
 class FakeExampleModule:
     """Used to patch a function that uses system-specific functions that
     cannot be patched automatically."""


### PR DESCRIPTION
- added Patcher.RUNTIME_SKIPMODULES to allow to skip modules whose name starts with specific strings, if the related debuuger is loaded
- only done for debugger used in PyCharm and VSCode

I have not added any documentation, as this is still experimental. We have to see if this is sufficient to fix the problems with the debugger (see #1083), or if more is needed.


#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
