### PR TITLE
Fix content update after flush

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -32,7 +32,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+#        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - python-version: "pypy-3.7"
             os: ubuntu-22.04

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ The released versions correspond to PyPI releases.
 ### Changes
 * added some preliminary support for Python 3.14
 
+### Fixes
+* fixed a problem with flushing if writing over the buffer end
+  (see [#1120](../../issues/1120))
+
 ## [Version 5.7.4](https://pypi.python.org/pypi/pyfakefs/5.7.4) (2025-01-14)
 Minor bugfix release.
 

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -910,8 +910,8 @@ class FakeFileWrapper:
         self._check_open_file()
 
         if self.allow_update:
-            contents = self._io.getvalue()
             if self._append:
+                contents = self._io.getvalue()
                 self._sync_io()
                 old_contents = self.file_object.byte_contents
                 assert old_contents is not None
@@ -919,6 +919,7 @@ class FakeFileWrapper:
                 self._set_stream_contents(contents)
             else:
                 self._io.flush()
+                contents = self._io.getvalue()
             changed = self.file_object.set_contents(contents, self._encoding)
             self.update_flush_pos()
             if changed:

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -1366,6 +1366,22 @@ class BufferingModeTest(FakeFileOpenTestBase):
                 x = r.read()
                 self.assertEqual(b"a" * 50, x)
 
+    def test_writing_over_buffer_end(self):
+        # regression test for #1120
+        dir_path = self.make_path("foo")
+        self.create_dir(dir_path)
+        file_path = self.os.path.join(dir_path, "bar.txt")
+        line_end_size = len(self.os.linesep)
+        char_count = io.DEFAULT_BUFFER_SIZE // 256 - line_end_size
+        for line_count in (255, 256, 257, 511, 512, 513):
+            with self.open(file_path, "w") as f:
+                for i in range(line_count):
+                    f.write("x" * char_count + "\n")
+
+            with self.open(file_path) as f:
+                lines = f.readlines()
+                self.assertEqual(line_count, len(lines))
+
 
 class RealBufferingTest(BufferingModeTest):
     def use_real_fs(self):


### PR DESCRIPTION
- caused missing content if writing over the buffer end
- fixes #1120
- temporarily disable Python 3.14 in CI (current alpha 5 fails some tests)

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
