### PR TITLE
Adapt to Python 3.14 alpha 5

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -32,8 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
-#        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - python-version: "pypy-3.7"
             os: ubuntu-22.04


### PR DESCRIPTION
- do not patch globber.scandir in 3.14
- switch off copy file range optimization (Linux only)

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [ ] Entry to release notes added - already there
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
