### PR TITLE
Ignore permissions in FakeFilesystem.get_object()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ The released versions correspond to PyPI releases.
 
 ### Changes
 * added some preliminary support for Python 3.14
+* change behavior of `FakeFilesystem.get_object()` to ignore permissions as it has been
+  before version 5.4.0 (see [#1122](../../issues/1122))
 
 ### Fixes
 * fixed a problem with flushing if writing over the buffer end
@@ -23,6 +25,7 @@ The released versions correspond to PyPI releases.
 * fixed a regression that could break tests under Posix in Python 3.12
   (see [#1126](../../issues/1126))
 * fixed behavior for `os.access` for symlinks under Windows
+* fixes permission problem on querying file properties (see [#1122](../../issues/1122))
 
 ## [Version 5.7.4](https://pypi.python.org/pypi/pyfakefs/5.7.4) (2025-01-14)
 Minor bugfix release.

--- a/pyfakefs/fake_scandir.py
+++ b/pyfakefs/fake_scandir.py
@@ -133,7 +133,10 @@ class ScanDirIter:
                 self.filesystem.get_open_file(path).get_object().path
             )
             self.path = ""
+            self.entry_iter = iter(tuple())
         else:
+            if path is None:
+                path = "."
             path = make_string_path(path)
             self.abspath = self.filesystem.absnormpath(path)
             self.path = to_string(path)

--- a/pyfakefs/tests/fake_os_test.py
+++ b/pyfakefs/tests/fake_os_test.py
@@ -1461,7 +1461,7 @@ class FakeOsModuleTest(FakeOsModuleTestBase):
         new_file = self.filesystem.get_object(new_file_path)
         self.assertNotEqual(new_file.st_mtime, old_file.st_mtime)
         self.os.rename(old_file_path, new_file_path)
-        new_file = self.filesystem.get_object(new_file_path, check_read_perm=False)
+        new_file = self.filesystem.get_object(new_file_path)
         self.assertEqual(new_file.st_mtime, old_file.st_mtime)
         self.assertEqual(new_file.st_mode, old_file.st_mode)
         self.assertEqual(new_file.st_uid, old_file.st_uid)
@@ -5439,6 +5439,11 @@ class FakeScandirTest(FakeOsModuleTestBase):
                 self.os.lstat(self.file_rel_link_path).st_ino,
                 self.dir_entries[5].inode(),
             )
+
+    def test_scandir_none(self):
+        result1 = [entry.path for entry in self.scandir(None)]
+        result2 = [entry.path for entry in self.scandir(".")]
+        self.assertEqual(result1, result2)
 
     def test_scandir_stat_nlink(self):
         # regression test for #350


### PR DESCRIPTION
- restores the behavior before version 5.4.0
- fix permission error on reading file type
- fix os.access() behavior for root user
- fix os.scandir(None) behavior
- see #1122

I had first tried to add more tests to `FakeFilesystemVsRealTest`, but have decided to leave that for later as it got a bit out of hand.
This is a minimal fix for the observed problems, and a reversal in the behavior of `FakeFilesystem.get_object()` so that it can be used as before independent of permissions.


#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
