### PR TITLE
Fix recursion on dynamic import from fake file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,12 @@ The released versions correspond to PyPI releases.
 * the default for `FakeFilesystem.shuffle_listdir_results` will change to `True` to reflect
   the real filesystem behavior
 
+## Unreleased
+
+### Fixes
+* fixed handling of dynamic imports from code in the fake filesystem in Python > 3.11
+  (see [#1121](../../issues/1121))
+
 ## [Version 5.8.0](https://pypi.python.org/pypi/pyfakefs/5.8.0) (2025-03-11)
 Adds preliminary support for Python 3.14.
 

--- a/pyfakefs/fake_io.py
+++ b/pyfakefs/fake_io.py
@@ -86,6 +86,7 @@ class FakeIoModule:
         newline: Optional[str] = None,
         closefd: bool = True,
         opener: Optional[Callable] = None,
+        is_fake_open_code: bool = False,
     ) -> Union[AnyFileWrapper, IO[Any]]:
         """Redirect the call to FakeFileOpen.
         See FakeFileOpen.call() for description.
@@ -101,6 +102,7 @@ class FakeIoModule:
             newline,
             closefd,
             opener,
+            is_fake_open_code,
         )
 
     if sys.version_info >= (3, 8):
@@ -118,7 +120,7 @@ class FakeIoModule:
                 and self.filesystem.exists(path)
                 or patch_mode == PatchMode.ON
             ):
-                return self.open(path, mode="rb")
+                return self.open(path, mode="rb", is_fake_open_code=True)
             # mostly this is used for compiled code -
             # don't patch these, as the files are probably in the real fs
             return self._io_module.open_code(path)

--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -82,11 +82,14 @@ def fake_open(
     newline: Optional[str] = None,
     closefd: bool = True,
     opener: Optional[Callable] = None,
+    is_fake_open_code: bool = False,
 ) -> Union[AnyFileWrapper, IO[Any]]:
     """Redirect the call to FakeFileOpen.
     See FakeFileOpen.call() for description.
     """
-    if is_called_from_skipped_module(
+    # We don't need to check this if we are in an `open_code` call
+    # from a faked file (and this might cause recursions in `linecache`)
+    if not is_fake_open_code and is_called_from_skipped_module(
         skip_names=skip_names,
         case_sensitive=filesystem.is_case_sensitive,
         check_open_code=sys.version_info >= (3, 12),

--- a/pyfakefs/tests/fake_filesystem_unittest_test.py
+++ b/pyfakefs/tests/fake_filesystem_unittest_test.py
@@ -848,6 +848,13 @@ class AutoPatchOpenCodeTestCase(fake_filesystem_unittest.TestCase):
             self.import_foo()
         assert stdout.getvalue() == "hello\n"
 
+    def test_dynamic_import(self):
+        # regression test for #1121
+        self.fs.create_file("/foo.py")
+        self.fs.create_file("/bar.py", contents="import foo")
+        sys.path.insert(0, "")
+        import foo  # noqa
+
 
 class TestOtherFS(fake_filesystem_unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
- happened in Python > 3.11 due to the handling of linecache in connection with a faked open_code call
- fixes #1121 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
