### PR TITLE
Adapt test for increased buffer size in Python 3.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ The released versions correspond to PyPI releases.
 * fixed handling of dynamic imports from code in the fake filesystem in Python > 3.11
   (see [#1121](../../issues/1121))
 
+### Infrastructure
+* adapt test for increased default buffer size in Python 3.14a6
+
 ## [Version 5.8.0](https://pypi.python.org/pypi/pyfakefs/5.8.0) (2025-03-11)
 Adds preliminary support for Python 3.14.
 

--- a/pyfakefs/tests/fake_open_test.py
+++ b/pyfakefs/tests/fake_open_test.py
@@ -1227,26 +1227,26 @@ class BufferingModeTest(FakeFileOpenTestBase):
     def test_writing_large_text_with_line_buffer(self):
         file_path = self.make_path("buffertest.bin")
         with self.open(file_path, "w", encoding="utf8", buffering=1) as f:
-            f.write("test" * 4000)
+            f.write("test" * 33000)
             with self.open(file_path, "r", encoding="utf8") as r:
                 x = r.read()
                 # buffer larger than default - written
-                self.assertEqual(16000, len(x))
+                self.assertEqual(132000, len(x))
             f.write("test")
             with self.open(file_path, "r", encoding="utf8") as r:
                 x = r.read()
                 # buffer not filled - not written
-                self.assertEqual(16000, len(x))
+                self.assertEqual(132000, len(x))
             f.write("\ntest")
             with self.open(file_path, "r", encoding="utf8") as r:
                 x = r.read()
                 # new line - buffer written
-                self.assertEqual(16009, len(x))
+                self.assertEqual(132009, len(x))
             f.write("\ntest")
             with self.open(file_path, "r", encoding="utf8") as r:
                 x = r.read()
                 # another new line - buffer written
-                self.assertEqual(16014, len(x))
+                self.assertEqual(132014, len(x))
 
     def test_writing_text_with_default_buffer(self):
         file_path = self.make_path("buffertest.txt")


### PR DESCRIPTION
- default buffer size has increased from 8 kB to 128 kB

#### Tasks
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
