### PR TITLE
Make workaround for a recursion more robust

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@ The released versions correspond to PyPI releases.
 ### Fixes
 * fixed handling of dynamic imports from code in the fake filesystem in Python > 3.11
   (see [#1121](../../issues/1121))
+* fixed workaround for recursion with pytest under Windows to ignore capitalization
+  of pytest executable (see [#1096](../../issues/1096))
 
 ### Infrastructure
 * adapt test for increased default buffer size in Python 3.14a6

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -86,7 +86,7 @@ from pyfakefs.fake_filesystem import (
     FakeFilesystem,
 )
 from pyfakefs.fake_os import use_original_os
-from pyfakefs.helpers import IS_PYPY
+from pyfakefs.helpers import IS_PYPY, IS_WIN
 from pyfakefs.legacy_packages import pathlib2, scandir
 from pyfakefs.mox3_stubout import StubOutForTesting
 
@@ -153,7 +153,9 @@ class LineCachePatcher:
 
             with use_original_os():
                 # workaround for updatecache problem with pytest under Windows, see #1096
-                if not filename.endswith(r"pytest.exe\__main__.py"):
+                if not IS_WIN or not filename.lower().endswith(
+                    r"pytest.exe\__main__.py"
+                ):
                     return self.linecache_updatecache(filename, module_globals)
                 return []
 


### PR DESCRIPTION
- ignore the pytest executable capitalization
- fixes #1096 (again)

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working - don't know how to test this
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
