### PR TITLE
Remove "in the fake filesystem" from OSError message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Changes
+* the message from an `OSError` raised in the fake filesystem has no longer the postfix
+  _"in the fake filesystem"_ (see [#1159](../../discussions/1159))
+
 ### Enhancements
 * added convenience function `add_package_metadata` to add the metadata of a given
   package to the fake filesystem (see [#1155](../../issues/1155))

--- a/docs/convenience.rst
+++ b/docs/convenience.rst
@@ -214,6 +214,8 @@ and you may fail to create new files if the fake file system is full.
 To get the file system size, you may use :py:meth:`get_disk_usage()<pyfakefs.fake_filesystem.FakeFilesystem.get_disk_usage>`, which is
 modeled after ``shutil.disk_usage()``.
 
+.. _pause_resume:
+
 Suspending patching
 ~~~~~~~~~~~~~~~~~~~
 Sometimes, you may want to access the real filesystem inside the test with
@@ -261,6 +263,8 @@ Here is the same code using a context manager:
             assert os.path.exists(real_temp_file.name)
         assert not os.path.exists(real_temp_file.name)
         assert os.path.exists(fake_temp_file.name)
+
+.. _simulate_os:
 
 Simulating other file systems
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -34,29 +34,29 @@ Features
   the real filesystem will work on the fake filesystem if running under
   ``pyfakefs``.
 
-- ``pyfakefs`` provides direct support for `pytest` (via the `fs` fixture)
-  and `unittest` (via a `TestCase` base class), but can also be used with
+- ``pyfakefs`` provides direct support for `pytest` (see :ref:`pytest_plugin`)
+  and `unittest` (see :ref:`unittest_usage`), but can also be used with
   other test frameworks.
 
 - Each ``pyfakefs`` test starts with an empty (except for the :ref:`os_temporary_directories`) file system,
   but it is possible to map files and directories from the real file system into the fake
-  filesystem if needed.
+  filesystem if needed (see :ref:`real_fs_access`).
 
 - No files in the real file system are changed during the tests, even in the
   case of writing to mapped real files.
 
 - ``pyfakefs`` keeps track of the filesystem size if configured. The file system
-  size can be configured arbitrarily. It is also possible to create files with a defined
-  size without setting contents.
+  size can be configured arbitrarily (see :ref:`set-fs-size`). It is also possible to create files
+  with a defined size without setting contents.
 
 - It is possible to pause and resume using the fake filesystem, if the
-  real file system has to be used in a test step.
+  real file system has to be used in a test step (see :ref:`pause_resume`).
 
 - ``pyfakefs`` defaults to the OS it is running on, but can also be configured
-  to test code running under another OS (Linux, macOS or Windows).
+  to test code running under another OS (Linux, macOS or Windows, see :ref:`simulate_os`).
 
 - ``pyfakefs`` can be configured to behave as if running as a root or as a
-  non-root user, independently from the actual user.
+  non-root user, independently from the actual user (see :ref:`allow_root_user`).
 
 .. _limitations:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,6 +5,7 @@ Test Scenarios
 --------------
 There are several approaches for implementing tests using ``pyfakefs``.
 
+.. _pytest_plugin:
 
 Patch using the pytest plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -53,6 +54,8 @@ respectively.
   will just serve as a reference to the active fake filesystem. That means that changes
   done in the fake filesystem inside a test will remain there until the respective scope
   ends (see also :ref:`nested_patcher_invocation`).
+
+.. _unittest_usage:
 
 Patch using fake_filesystem_unittest
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyfakefs/fake_file.py
+++ b/pyfakefs/fake_file.py
@@ -531,7 +531,7 @@ class FakeDirectory(FakeFile):
             and not self.filesystem.is_windows_fs
             and not self.has_permission(helpers.PERM_WRITE)
         ):
-            raise OSError(errno.EACCES, "Permission Denied", self.path)
+            self.filesystem.raise_os_error(errno.EACCES, self.path)
 
         path_object_name: str = to_string(path_object.name)
         if path_object_name in self.entries:
@@ -845,7 +845,7 @@ class FakeFileWrapper:
         """Return the file descriptor of the file object."""
         if self.filedes is not None:
             return self.filedes
-        raise OSError(errno.EBADF, "Invalid file descriptor")
+        self._filesystem.raise_os_error(errno.EBADF)
 
     def close(self) -> None:
         """Close the file."""
@@ -1258,7 +1258,7 @@ class StandardStreamWrapper:
         """Return the file descriptor of the wrapped standard stream."""
         if self.filedes is not None:
             return self.filedes
-        raise OSError(errno.EBADF, "Invalid file descriptor")
+        raise OSError(errno.EBADF, os.strerror(errno.EBADF))
 
     def read(self, n: int = -1) -> bytes:
         return cast(bytes, self._stream_object.read())
@@ -1313,7 +1313,7 @@ class FakeDirWrapper:
         """Return the file descriptor of the file object."""
         if self.filedes is not None:
             return self.filedes
-        raise OSError(errno.EBADF, "Invalid file descriptor")
+        raise OSError(errno.EBADF, os.strerror(errno.EBADF))
 
     def close(self) -> None:
         """Close the directory."""
@@ -1388,7 +1388,7 @@ class FakePipeWrapper:
         """Return the fake file descriptor of the pipe object."""
         if self.filedes is not None:
             return self.filedes
-        raise OSError(errno.EBADF, "Invalid file descriptor")
+        raise OSError(errno.EBADF, os.strerror(errno.EBADF))
 
     def read(self, numBytes: int = -1) -> bytes:
         """Read from the real pipe."""

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -488,7 +488,7 @@ class FakeFilesystem:
             filename: The name of the affected file, if any.
             winerror: Windows only - the specific Windows error code.
         """
-        message = os.strerror(err_no) + " in the fake filesystem"
+        message = os.strerror(err_no)
         if winerror is not None and sys.platform == "win32" and self.is_windows_fs:
             raise OSError(err_no, message, filename, winerror)
         raise OSError(err_no, message, filename)
@@ -1885,7 +1885,7 @@ class FakeFilesystem:
         """
         path_str = make_string_path(path)
         if not path_str:
-            raise OSError(errno.ENOENT, path_str)
+            self.raise_os_error(errno.ENOENT, path_str)
         if path_str == matching_string(path_str, self.root.name):
             # The root directory will never be a link
             return self.root
@@ -1915,7 +1915,7 @@ class FakeFilesystem:
             )
         except KeyError:
             pass
-        raise OSError(errno.ENOENT, path_str)
+        self.raise_os_error(errno.ENOENT, path_str)
 
     def add_object(self, file_path: AnyStr, file_object: AnyFile) -> None:
         """Add a fake file or directory into the filesystem at file_path.

--- a/pyfakefs/tests/fake_filesystem_shutil_test.py
+++ b/pyfakefs/tests/fake_filesystem_shutil_test.py
@@ -212,6 +212,26 @@ class FakeShutilModuleTest(RealFsTestCase):
         self.assertTrue(os.path.exists(dst_file))
         self.assertEqual(os.stat(src_file).st_mode, os.stat(dst_file).st_mode)
 
+    def test_permission_error_message(self):
+        self.check_posix_only()
+        dst_dir = Path(self.make_path("home1"))
+        src_dir2 = os.path.join(dst_dir, "dir1")
+        os.makedirs(src_dir2)
+        dst_dir.chmod(0o555)
+        src_dir = Path(self.make_path("drive1"))
+        os.makedirs(src_dir)
+        src_file = src_dir / "new.txt"
+        src_file.touch()
+
+        msg = f"[Errno 13] Permission denied: '{dst_dir}'"
+        with self.assertRaises(PermissionError, msg=msg):
+            shutil.copy2(src_file, dst_dir)
+
+        dst_dir2 = dst_dir / "dir2"
+        msg = f"[Errno 13] Permission denied: '{dst_dir2}'"
+        with self.assertRaises(PermissionError, msg=msg):
+            shutil.move(src_dir2, dst_dir2)
+
     def test_copy_directory(self):
         src_file = self.make_path("xyzzy")
         parent_directory = self.make_path("parent")


### PR DESCRIPTION
- makes it more consistent with real messages
- documentation: add a few links to the intro
- see #1159

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
