### PR TITLE
Add missing `mode` property to fake file wrapper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ The released versions correspond to PyPI releases.
   (see [#1121](../../issues/1121))
 * fixed workaround for recursion with pytest under Windows to ignore capitalization
   of pytest executable (see [#1096](../../issues/1096))
+* added missing `mode` property to fake file wrapper (see [#1162](../../issues/1096))
 
 ### Infrastructure
 * adapt test for increased default buffer size in Python 3.14a6

--- a/pyfakefs/fake_open.py
+++ b/pyfakefs/fake_open.py
@@ -160,7 +160,7 @@ class FakeFileOpen:
                 flushed if buffer size is exceeded. The default (-1) uses a
                 system specific default buffer size. Text line mode (e.g.
                 buffering=1 in text mode) is not supported.
-            encoding: The encoding used to encode unicode strings / decode
+            encoding: The encoding used to encode Unicode strings / decode
                 bytes.
             errors: (str) Defines how encoding errors are handled.
             newline: Controls universal newlines, passed to stream object.
@@ -270,9 +270,8 @@ class FakeFileOpen:
         fakefile = FakeFileWrapper(
             file_object,
             file_path,
-            update=open_modes.can_write and can_write,
-            read=open_modes.can_read,
-            append=open_modes.append,
+            open_modes=open_modes,
+            allow_update=open_modes.can_write and can_write,
             delete_on_close=self._delete_on_close,
             filesystem=self.filesystem,
             newline=newline,


### PR DESCRIPTION
- conforms to the IO protocol
- fixes #1162

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
