### PR TITLE
Fix instantiation of standalone FakePathlibModule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,9 @@ The released versions correspond to PyPI releases.
   (see [#1121](../../issues/1121))
 * fixed workaround for recursion with pytest under Windows to ignore capitalization
   of pytest executable (see [#1096](../../issues/1096))
-* added missing `mode` property to fake file wrapper (see [#1162](../../issues/1096))
+* added missing `mode` property to fake file wrapper (see [#1162](../../issues/1162))
+* fixed instantiation of a standalone `FakePathlibModule` for Python >= 3.11
+  (see [#1169](../../issues/1169))
 
 ### Infrastructure
 * adapt test for increased default buffer size in Python 3.14a6

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -2614,6 +2614,7 @@ class RealFileSystemAccessTest(RealFsTestCase):
 
     @unittest.skipIf(pytest is None, "pytest is not installed")
     @unittest.skipIf(sys.version_info < (3, 8), "importlib.metadata not available")
+    @unittest.skipIf("pathlib2" in sys.modules, "pathlib2 may break this test")
     def test_add_package_metadata(self):
         parent_path = pathlib.Path(pytest.__file__).parent.parent
         pytest_dist_path = parent_path / f"pytest-{pytest.__version__}.dist-info"

--- a/pyfakefs/tests/fake_pathlib_test.py
+++ b/pyfakefs/tests/fake_pathlib_test.py
@@ -31,7 +31,8 @@ from unittest import mock
 from unittest.mock import patch
 
 from pyfakefs import fake_pathlib, fake_filesystem, fake_filesystem_unittest, fake_os
-from pyfakefs.fake_filesystem import OSType
+from pyfakefs.fake_filesystem import OSType, FakeFilesystem
+from pyfakefs.fake_pathlib import FakePathlibModule
 from pyfakefs.helpers import IS_PYPY, is_root
 from pyfakefs.tests.skipped_pathlib import (
     check_exists_pathlib,
@@ -1644,6 +1645,14 @@ class SkipPathlibTest(fake_filesystem_unittest.TestCase):
     )
     def test_exists(self):
         self.assertTrue(check_exists_pathlib())
+
+
+class InstantiatedPathlibTest(unittest.TestCase):
+    def test_instantiated_pathlib(self):
+        fake_fs = FakeFilesystem()
+        fake_pathlib_module = FakePathlibModule(fake_fs)
+        top_level_dirs = list(fake_pathlib_module.Path("/").iterdir())
+        self.assertEqual(0, len(top_level_dirs))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- needs a patched os in Python >= 3.11
- fixes #1169 

This may break one rather special test if `pathlib2` is installed, but I'm goin to ignore this - `pathlib2` is depretated and will be removed in pyfakefs 6.

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
