### PR TITLE
Add support for new strict value "ALLOW_MISSING" in os.path.realpath

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ The released versions correspond to PyPI releases.
 * added missing `mode` property to fake file wrapper (see [#1162](../../issues/1162))
 * fixed instantiation of a standalone `FakePathlibModule` for Python >= 3.11
   (see [#1169](../../issues/1169))
+* added support for new value "ALLOW_MISSING" of `strict` argument in `os.path.realpath`
+  (introduced in latest patch version of Python >= 3.10, see [#1180](../../issues/1180))
 
 ### Infrastructure
 * adapt test for increased default buffer size in Python 3.14a6

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -1036,6 +1036,23 @@ class FakePathModuleTest(TestCase):
             f"{root_dir}foo!bar", self.os.path.realpath("bar", strict=True)
         )
 
+    @unittest.skipIf(
+        not hasattr(os.path, "ALLOW_MISSING"),
+        "ALLOW_MISSING has been added in different patch versions",
+    )
+    def test_realpath_allow_missing(self):
+        f = self.filesystem.create_file("!foo!bar")
+        root_dir = self.filesystem.root_dir_name
+        self.filesystem.cwd = f"{root_dir}foo"
+        self.assertEqual(
+            "!foo!baz",
+            self.os.path.realpath("baz", strict=os.path.ALLOW_MISSING),  # type: ignore[attr-defined]
+        )
+        if not is_root():
+            self.os.chmod(f.path, 0)
+            with self.raises_os_error(errno.EACCES):
+                self.os.path.realpath(f.path, strict=os.path.ALLOW_MISSING)  # type: ignore[attr-defined]
+
     def test_samefile(self):
         file_path1 = "!foo!bar!baz"
         file_path2 = "!foo!bar!boo"


### PR DESCRIPTION
- has been introduced in latest patch version of Python >= 3.10
- fixes #1180

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
