### PR TITLE
Add thread lock for global patches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ The released versions correspond to PyPI releases.
 ### Changes
 * the message from an `OSError` raised in the fake filesystem has no longer the postfix
   _"in the fake filesystem"_ (see [#1159](../../discussions/1159))
-* changed implementation of `FakeShutilModule` to be able to be used without the patcher
+* changed implementation of `FakeShutilModule` to prepare it for usage without the patcher
   (see [#1171](../../discussions/1171))
 
 ### Enhancements

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -15,15 +15,9 @@ New in pyfakefs 3.0.
 
 Usage:
 
-* With Patcher:
-  If using `fake_filesystem_unittest.TestCase`, pytest fs fixture,
-  or directly `Patcher`, pathlib gets replaced
-  by fake_pathlib together with other file system related modules.
-
-* Stand-alone with FakeFilesystem:
-  `filesystem = fake_filesystem.FakeFilesystem()`
-  `fake_pathlib_module = fake_pathlib.FakePathlibModule(filesystem)`
-  `path = fake_pathlib_module.Path('/foo/bar')`
+If using `fake_filesystem_unittest.TestCase`, pytest fs fixture,
+or directly `Patcher`, pathlib gets replaced
+by fake_pathlib together with other file system related modules.
 
 Note: as the implementation is based on FakeFilesystem, all faked classes
 (including PurePosixPath, PosixPath, PureWindowsPath and WindowsPath)
@@ -867,11 +861,6 @@ class FakePathlibModule:
 
     Automatically created if using `fake_filesystem_unittest.TestCase`,
     the `fs` fixture, the `patchfs` decorator, or directly the `Patcher`.
-
-    For creating it separately, a `fake_filesystem` instance is needed::
-
-        filesystem = fake_filesystem.FakeFilesystem()
-        fake_pathlib_module = fake_pathlib.FakePathlibModule(filesystem)
     """
 
     def __init__(self, filesystem, from_patcher=False):

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -1045,7 +1045,7 @@ class FakePathModuleTest(TestCase):
         root_dir = self.filesystem.root_dir_name
         self.filesystem.cwd = f"{root_dir}foo"
         self.assertEqual(
-            "!foo!baz",
+            f"{root_dir}foo!baz",
             self.os.path.realpath("baz", strict=os.path.ALLOW_MISSING),  # type: ignore[attr-defined]
         )
         if not is_root():


### PR DESCRIPTION
- remove incorrect documentation about stand-alone usage
- fix patching of global variables

This mainly fixes the latest PR that was quite buggy, and had added incorrect documentation, see #1171 and #1182.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working - n/a
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
