### PR TITLE
Fix packaging problems with 5.9.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ The released versions correspond to PyPI releases.
   the real filesystem behavior
 * remove support for Python versions before 3.10 (if needed, patches may be backported to the 5.x branch)
 
+## Unreleased
+
+### Fixes
+* fixed handling of added `strict` argument in Python 3.9.23
+
 ## [Version 5.9.0](https://pypi.python.org/pypi/pyfakefs/5.8.0) (2025-06-21)
 Adds support for an API change in latest Python patch releases.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ The released versions correspond to PyPI releases.
 
 ### Fixes
 * fixed handling of added `strict` argument in Python 3.9.23
+* make sure test files are packaged (see [#1186](../../issues/1186))
 
 ## [Version 5.9.0](https://pypi.python.org/pypi/pyfakefs/5.8.0) (2025-06-21)
 Adds support for an API change in latest Python patch releases.
@@ -25,7 +26,7 @@ Adds support for an API change in latest Python patch releases.
 * the message from an `OSError` raised in the fake filesystem has no longer the postfix
   _"in the fake filesystem"_ (see [#1159](../../discussions/1159))
 * changed implementation of `FakeShutilModule` to prepare it for usage without the patcher
-  (see [#1171](../../discussions/1171))
+  (see [#1171](../../issues/1171))
 
 ### Enhancements
 * added convenience function `add_package_metadata` to add the metadata of a given

--- a/pyfakefs/fake_path.py
+++ b/pyfakefs/fake_path.py
@@ -359,9 +359,11 @@ class FakePathModule:
         """Return the canonical path of the specified filename, eliminating any
         symbolic links encountered in the path.
         """
-        if strict is not None and sys.version_info < (3, 10):
-            raise TypeError("realpath() got an unexpected keyword argument 'strict'")
         has_allow_missing = hasattr(os.path, "ALLOW_MISSING")
+        # the strict argument was backported to Python 3.9.23
+        # together with support for os.path.ALLOW_MISSING
+        if strict is not None and sys.version_info < (3, 10) and not has_allow_missing:
+            raise TypeError("realpath() got an unexpected keyword argument 'strict'")
         if has_allow_missing and strict == os.path.ALLOW_MISSING:  # type: ignore[attr-defined]
             # ignores non-existing file, but not other errors
             ignored_error: Any = FileNotFoundError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,11 @@ xdist = [
 ]
 
 [tool.setuptools]
-packages = ["pyfakefs"]
+include-package-data = true
+
 [tool.setuptools.package-data]
-pyfakefs = ["py.typed"]
+where = ["pyfakefs"]
+pyfakefs = ["py.typed", "**/*.parquet", "**/*.xlsx"]
 
 [tool.setuptools.dynamic]
 version = { attr = "pyfakefs.__version__" }


### PR DESCRIPTION
- fixes the handling of `strict` argument in `os.path.realpath` in Python >= 3.9.23
- adds back the tests into the PyPi packages (fixes #1186)

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working n/a
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
