### PR TITLE
Fix handling of pausing fs during reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ The released versions correspond to PyPI releases.
 
 ## Unreleased
 
+### Fixes
+* fixed an interaction problem of `fs` with other pytest fixtures (see [#1200](../../issues/1200))
+
 ### Infrastructure
 * fixed some warnings in tests (see [#1190](../../issues/1190))
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -43,6 +43,9 @@ you can define a longer name in your ``conftest.py`` and use that in your tests:
         """
         yield fs
 
+.. note:: Filesystem patching is paused in the pytest logreport phases to ensure that
+  logs are correctly written to the real filesystem.
+
 Class-, module- and session-scoped fixtures
 ...........................................
 For convenience, class-, module- and session-scoped fixtures with the same
@@ -54,6 +57,9 @@ respectively.
   will just serve as a reference to the active fake filesystem. That means that changes
   done in the fake filesystem inside a test will remain there until the respective scope
   ends (see also :ref:`nested_patcher_invocation`).
+
+.. note:: To avoid unwanted side-effects, the patching is paused between the tests,
+  even if the fixture is still active.
 
 .. _unittest_usage:
 

--- a/pyfakefs/fake_filesystem_unittest.py
+++ b/pyfakefs/fake_filesystem_unittest.py
@@ -789,7 +789,7 @@ class Patcher:
             "io": fake_io.FakeIoModule,
             "pathlib": fake_pathlib_module,
         }
-        if sys.version_info >= (3, 13):
+        if sys.version_info[:2] == (3, 13):
             # for Python 3.13, we need both pathlib (path with __init__.py) and
             # pathlib._local (has the actual implementation);
             # depending on how pathlib is imported, either may be used
@@ -806,10 +806,10 @@ class Patcher:
         # be contained in - this allows for alternative modules like
         # `pathlib` and `pathlib2`
         self._class_modules["Path"] = ["pathlib"]
-        if sys.version_info >= (3, 13):
+        if sys.version_info[:2] == (3, 13):
             self._class_modules["Path"].append("pathlib._local")
         self._unfaked_module_classes["pathlib"] = fake_pathlib.RealPathlibModule
-        if sys.version_info >= (3, 13):
+        if sys.version_info[:2] == (3, 13):
             self._unfaked_module_classes["pathlib._local"] = (
                 fake_pathlib.RealPathlibModule
             )

--- a/pyfakefs/pytest_tests/test_fs_with_monkeypatch.py
+++ b/pyfakefs/pytest_tests/test_fs_with_monkeypatch.py
@@ -1,0 +1,12 @@
+from pyfakefs.fake_filesystem import FakeFileOpen
+
+
+def test_monkeypatch_with_fs(fs, monkeypatch):
+    """Regression test for issue 1200"""
+    fake_open = FakeFileOpen(fs)
+    monkeypatch.setattr("builtins.open", fake_open, raising=False)
+
+
+def test_open():
+    """Tests if open is poisoned by the above test"""
+    assert "built-in" in str(open)


### PR DESCRIPTION
- use hookwrapper to disable patching during reporting
- disable patching between tests for non function-scope fixtures
- fixes #1200

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [x] For documentation changes: The Read the Docs preview builds and looks as expected
