### PR TITLE
Fix fake_filesystem.add_package_metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ The released versions correspond to PyPI releases.
 * a warning is now issued if trying to create a nested fake filesystem with custom arguments
   (custom arguments are ignored in this case, as the existing fake filesystem is used)
 
+## Fixes
+* fixed `fake_filesystem.add_package_metadata` that had never worked correctly
+  (see [#1205](../../issues/1205))
+
 ## [Version 5.9.2](https://pypi.python.org/pypi/pyfakefs/5.9.2) (2025-07-30)
 Fixes interaction with pytest.
 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -2544,12 +2544,19 @@ class FakeFilesystem:
 
         from importlib.metadata import distribution, PackageNotFoundError
 
-        dist_files = distribution(package_name).files
-        if dist_files is None:
-            raise PackageNotFoundError(package_name)
-
-        for metadata_file in dist_files:
-            self.add_real_file(metadata_file.locate())
+        # we have to pause patching to get the distribution
+        # from the real filesystem if we are in patch mode
+        if self.patcher:
+            self.pause()
+        try:
+            dist_files = distribution(package_name).files
+            if dist_files is None:
+                raise PackageNotFoundError(package_name)
+            for metadata_file in dist_files:
+                self.add_real_file(metadata_file.locate())
+        finally:
+            if self.patcher:
+                self.resume()
 
     def create_file_internally(
         self,

--- a/pyfakefs/pytest_tests/pytest_fixture_test.py
+++ b/pyfakefs/pytest_tests/pytest_fixture_test.py
@@ -9,6 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pathlib
+import sys
 
 # Example for a test using a custom pytest fixture with an argument to Patcher
 
@@ -54,3 +56,17 @@ def check_that_example_file_is_in_fake_fs():
         assert file.read() == "stuff here"
     assert example.EXAMPLE_FILE.read_text() == "stuff here"
     assert example.EXAMPLE_FILE.is_file()
+
+
+pytest_parent_path = pathlib.Path(pytest.__file__).parent.parent
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="importlib.metadata not available"
+)
+def test_add_package_metadata(fs):
+    pytest_dist_path = pytest_parent_path / f"pytest-{pytest.__version__}.dist-info"
+    assert not fs.exists(pytest_dist_path)
+    fs.add_package_metadata("pytest")
+    assert fs.exists(pytest_dist_path)
+    assert fs.exists(pytest_dist_path / "METADATA")


### PR DESCRIPTION
- pause patching to get the metadata path
- seems to never have properly worked
- fixes #1205 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
