### PR TITLE
Fix the pinned build-system version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@ The released versions correspond to PyPI releases.
 * fixed `fake_filesystem.add_package_metadata` that had never worked correctly
   (see [#1205](../../issues/1205))
 
+### Infrastructure
+* updated the package build-system minimum version to setuptools v61.2 and higher
+
 ## [Version 5.9.2](https://pypi.python.org/pypi/pyfakefs/5.9.2) (2025-07-30)
 Fixes interaction with pytest.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
-requires = ["setuptools>=45"]
+# change this to be "setuptools>=77.0.3" after 3.8 is out of support
+requires = ["setuptools>=61.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyfakefs"
 description = "Implements a fake file system that mocks the Python file system modules."
 readme = "README.md"
-# change this to be PEP-639-conform after 3.8 is out of support
+# change this to be "Apache-2.0" after 3.8 is out of support
 license = {file = "COPYING"}
 
 authors = [


### PR DESCRIPTION
#### Describe the changes

setuptools v45.x doesn't support `pyproject.toml` files.
v62.1.x and higher do, and continue to support Python 3.7.

Reproducer:

```
# Create a venv
python -m venv venv-demo
source venv-demo/bin/activate

# Install setuptools and build
python -m pip install setuptools==45.0.0 build

# Build the package using the already-installed setuptools
python -m build --no-isolation
```

This results in the following error:

```
ERROR Backend 'setuptools.build_meta' is not available.
```

Changing the reproducer to use setuptools 61.2.0 demonstrates that the issue is resolved.

#### Tasks
- [ ] Unit tests added that reproduce the issue or prove feature is working
- [ ] Fix or feature added
- [x] Entry to release notes added
- [x] Pre-commit CI shows no errors
- [x] Unit tests passing
- [ ] For documentation changes: The Read the Docs preview builds and looks as expected
