### PR TITLE
Temporarily disable failing test

### DIFF
--- a/pyfakefs/tests/fake_tempfile_test.py
+++ b/pyfakefs/tests/fake_tempfile_test.py
@@ -18,6 +18,7 @@ if using `Patcher` (via `fake_filesystem_unittest`).
 
 import os
 import stat
+import sys
 import tempfile
 import unittest
 
@@ -88,6 +89,10 @@ class FakeTempfileModuleTest(fake_filesystem_unittest.TestCase):
         self.assertTrue(self.fs.exists(dirname))
         self.assertEqual(self.fs.get_object(dirname).st_mode, stat.S_IFDIR | 0o700)
 
+    @unittest.skipIf(
+        sys.version_info[:3] == (3, 13, 5),
+        "Not working on Debian with this version, see #1214",
+    )
     def test_temporary_directory(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             self.assertTrue(tmpdir)


### PR DESCRIPTION
- the specific Python version is currently only used in the Debian container
- see #1214

#### Tasks
- [ ] Pre-commit CI shows no errors
- [ ] Unit tests passing
