### PR TITLE
Make create_link error on cross-device links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ The released versions correspond to PyPI releases.
 * fixed `os.ftruncate` to inspect the `FakeFileWrapper` returned by
   `get_open_file(fd)`
   (see [#1331](https://github.com/pytest-dev/pyfakefs/issues/1331))
+* fixed cross-device hard links incorrectly succeeding
+  (see [#1337](https://github.com/pytest-dev/pyfakefs/issues/1337))
 
 ## [Version 6.2.0](https://pypi.python.org/pypi/pyfakefs/6.2.0) (2026-04-12)
 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1870,7 +1870,7 @@ class FakeFilesystem:
             allow_fd: If `True`, `file_path` may be an open file descriptor
             check_read_perm: If `True`, raises `OSError` if a parent directory
                 does not have read permission
-            check_read_perm: If `True`, raises `OSError` if a parent directory
+            check_exe_perm: If `True`, raises `OSError` if a parent directory
                 does not have execute permission
             check_owner: If `True`, and ``check_read_perm`` is also `True`,
                 only checks read permission if the current user id is
@@ -2782,10 +2782,20 @@ class FakeFilesystem:
         except OSError:
             self.raise_os_error(errno.ENOENT, old_path_str)
 
+        # Guaranteed to resolve because we either created it or errored earlier
+        new_dir_object = self.resolve(
+            new_parent_directory, follow_symlinks=follow_symlinks, check_read_perm=False
+        )
+
         if old_file.st_mode & S_IFDIR:
             self.raise_os_error(
                 errno.EACCES if self.is_windows_fs else errno.EPERM,
                 old_path_str,
+            )
+
+        if old_file.st_dev != new_dir_object.st_dev:
+            self.raise_os_error(
+                errno.EXDEV, f"{old_path_str} -> {new_parent_directory}/{new_basename}"
             )
 
         # abuse the name field to control the filename of the

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -670,7 +670,8 @@ class FakeFilesystemUnitTest(TestCase):
         dest = "/mnt/dir2/myotherfile.txt"
         self.filesystem.create_file(source)
 
-        with self.assertRaisesRegex(OSError, "Invalid cross-device link"):
+        # different error messages on different OSes, but all include the word "link"
+        with self.assertRaisesRegex(OSError, "link"):
             self.filesystem.create_link(source, dest)
 
     def test_resolve_object(self):

--- a/pyfakefs/tests/fake_filesystem_test.py
+++ b/pyfakefs/tests/fake_filesystem_test.py
@@ -664,6 +664,15 @@ class FakeFilesystemUnitTest(TestCase):
         self.assertTrue(self.filesystem.exists(path))
         self.assertTrue(self.filesystem.exists(target_path))
 
+    def test_create_cross_device_link(self):
+        self.filesystem.add_mount_point("/mnt/dir1")
+        source = "/mnt/dir1/myfile.txt"
+        dest = "/mnt/dir2/myotherfile.txt"
+        self.filesystem.create_file(source)
+
+        with self.assertRaisesRegex(OSError, "Invalid cross-device link"):
+            self.filesystem.create_link(source, dest)
+
     def test_resolve_object(self):
         target_path = "dir/target"
         target_contents = "0123456789ABCDEF"


### PR DESCRIPTION
#### Describe the changes

See https://github.com/pytest-dev/pyfakefs/issues/1337

The current hardlink implementation in pyfakefs does not raise an error on a cross-device link, while `os.file` does. This PR raises an OSError if the source and destination files have different device IDs.

Unit test pass:

```
$ python -m pyfakefs.tests.all_tests &> test_out.log
$ echo $?
0
```

#### Tasks
- [X] Unit tests added that reproduce the issue or prove feature is working
- [X] Fix or feature added
- [X] Entry to release notes added
- [X] Pre-commit CI shows no errors
- [ ] Unit tests passing
- ~For documentation changes: The Read the Docs preview builds and looks as expected~
